### PR TITLE
returns funds actually spent when calculating contribution

### DIFF
--- a/contracts/ETO/ETOTerms.sol
+++ b/contracts/ETO/ETOTerms.sol
@@ -391,6 +391,8 @@ contract ETOTerms is
                 if (discountedAmount > 0) {
                     // always round down when calculating tokens
                     fixedSlotEquityTokenInt = discountedAmount / calculatePriceFraction(wlTicket.fullTokenPriceFrac);
+                    // todo: compute effective amount spent without the rounding
+                    // discountAmount = fixedSlotEquityTokenInt *  calculatePriceFraction(wlTicket.fullTokenPriceFrac);
                 }
             }
         }
@@ -400,14 +402,18 @@ contract ETOTerms is
             if (applyWhitelistDiscounts && WHITELIST_DISCOUNT_FRAC > 0) {
                 // will not overflow, WHITELIST_DISCOUNT_FRAC < Q18 from constructor, also round down
                 equityTokenInt = remainingAmount / calculatePriceFraction(10**18 - WHITELIST_DISCOUNT_FRAC);
+                // todo: compute effective amount spent without the rounding
+                // remainingAmount = equityTokenInt * calculatePriceFraction(10**18 - WHITELIST_DISCOUNT_FRAC);
             } else {
                 // use pricing along the curve
                 equityTokenInt = calculateTokenAmount(totalContributedEurUlps + discountedAmount, remainingAmount);
+                // todo: remove function above and calculate directly
+                // remainingAmount = equityTokenInt * fullPrice;
             }
         }
         // should have all issued tokens
         equityTokenInt += fixedSlotEquityTokenInt;
-
+        // todo: return remainingAmount as effective amount spent for the least gas used
     }
 
     function addWhitelistInvestorPrivate(

--- a/test/ETO/ETOCommitment.js
+++ b/test/ETO/ETOCommitment.js
@@ -1745,17 +1745,21 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       const neuAmount = investorShare(await neumark.incremental(amount));
       expect(contrib[5]).to.be.bignumber.eq(neuAmount);
       expect(contrib[6]).to.be.false;
+      // todo: now just returns 'amount' write set of tests when there's actual implementation
+      expect(contrib[7]).to.be.bignumber.eq(amount);
       // invest
       await investAmount(investors[0], amount, "EUR");
       // next contrib
       const contrib2 = await etoCommitment.calculateContribution(investors[0], false, amount);
       expect(contrib2[4]).to.be.bignumber.eq(contrib[4]);
+      expect(contrib[7]).to.be.bignumber.eq(amount);
       // NEU reward drops
       expect(contrib2[5]).to.be.bignumber.lt(contrib[5]);
       // icbm contrib
       const contrib3 = await etoCommitment.calculateContribution(investors[0], true, amount);
       expect(contrib3[4]).to.be.bignumber.eq(contrib[4]);
       expect(contrib3[5]).to.be.bignumber.eq(0);
+      expect(contrib[7]).to.be.bignumber.eq(amount);
     });
 
     it("should calculate contribution in whitelist with discounts", async () => {


### PR DESCRIPTION
when investor acquires tokens in commitment contract we calculate the number of tokens by rounding it down when the amount could buy non integer number of tokens.
for example if the token costs 100 euro and you send 150 you'll still have 1 token and you lose 50 euro.
we round down to prevent rounding attacks when people get more tokens that they send money (ROUND HALF UP would produce 2 tokens here).

thus we add how much money was actually spent. investors should send exactly this amount not to lose any funds.

this also solves a few smaller problems in calculations.

current PR is a mockup that will always return amount being spent. we need it to continue working on UI