### PR TITLE
raise block gas limit to 8 million

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -63,7 +63,7 @@ module.exports = {
   networks: {
     localhost: {
       network_id: "*",
-      gas: 6800000,
+      gas: 8000000,
       gasPrice: 21000000000,
       from: "0x8a194c13308326173423119f8dcb785ce14c732b",
       deploymentConfigOverride: devNetworkDeploymentConfigOverride,
@@ -72,13 +72,13 @@ module.exports = {
     inprocess: {
       network_id: "*",
       provider: Ganache.provider({
-        gasLimit: 6800000,
+        gasLimit: 8000000,
         accounts: Array(10).fill({ balance: "12300000000000000000000000" }),
       }),
     },
     nf_private: {
       network_id: "17",
-      gas: 6800000,
+      gas: 8000000,
       gasPrice: 21000000000,
       from: "0x8a194c13308326173423119f8dcb785ce14c732b",
       deploymentConfigOverride: devNetworkDeploymentConfigOverride,
@@ -89,7 +89,7 @@ module.exports = {
     },
     nf_private_io: {
       network_id: "17",
-      gas: 6800000,
+      gas: 8000000,
       gasPrice: 21000000000,
       from: "0x8a194c13308326173423119f8dcb785ce14c732b",
       deploymentConfigOverride: devNetworkDeploymentConfigOverride,
@@ -104,7 +104,7 @@ module.exports = {
     },
     forked_live: {
       network_id: 72,
-      gas: 6800000, // close to current mainnet limit
+      gas: 8000000, // close to current mainnet limit
       gasPrice: 5000000000,
       from: "0x8a194c13308326173423119f8dcb785ce14c732b",
       deploymentConfigOverride: forkedLiveNetworkDeploymentConfigOverride,
@@ -115,7 +115,7 @@ module.exports = {
     },
     forked_nano_live: {
       network_id: 72,
-      gas: 6800000,
+      gas: 8000000,
       provider: nanoProvider(
         "http://ethexp2-node.neustg.net:8545",
         // "44'/60'/0'/1",
@@ -130,7 +130,7 @@ module.exports = {
     },
     live: {
       network_id: 1, // Ethereum public network
-      gas: 6800000, // close to current mainnet limit
+      gas: 8000000, // close to current mainnet limit
       gasPrice: 5000000000, // 21 gwei /shannon
       deploymentConfigOverride: {
         ICBM_COMMITMENT_ADDRESS: "0xf432cec23b2a0d6062b969467f65669de81f4653",
@@ -147,7 +147,7 @@ module.exports = {
     },
     console_pk_live: {
       network_id: 1, // Ethereum public network
-      gas: 6800000, // close to current mainnet limit
+      gas: 8000000, // close to current mainnet limit
       gasPrice: 6000000000, // 21 gwei /shannon
       deploymentConfigOverride: {
         ICBM_COMMITMENT_ADDRESS: "0xf432cec23b2a0d6062b969467f65669de81f4653",
@@ -181,7 +181,7 @@ module.exports = {
       network_id: "*",
       host: "localhost",
       port: 8545,
-      gas: 6800000,
+      gas: 8000000,
       gasPrice: 8000000000,
       from: "0x8a194c13308326173423119f8dcb785ce14c732b",
       deploymentConfigOverride: {
@@ -193,16 +193,16 @@ module.exports = {
     inprocess_test: {
       network_id: "*",
       provider: Ganache.provider({
-        gasLimit: 6800000,
+        gasLimit: 8000000,
         accounts: Array(10).fill({ balance: "12300000000000000000000000" }),
       }),
-      gas: 6800000,
+      gas: 8000000,
     },
     localhost_test: {
       network_id: "*",
       host: "localhost",
       port: 8545,
-      gas: 6800000,
+      gas: 8000000,
     },
     inprocess_massive_test: {
       network_id: "*",


### PR DESCRIPTION
while the current limit is at 10 million (https://ethgasstation.info/blog/ethereum-block-size/)
I chose to only raise to 8, so that we will be conscious of any changes to increase our contract size

## NOTE: For this to be effective the gas limit has to be raised on our parity-clone as well, see PR
https://github.com/Neufund/parity-instant-seal-byzantium-enabled/pull/25

## Motivation:

adding an extra convenience function to ``` MockEtoCommitment.sol``` was not possible as it would go above the block gas limit 