### PR TITLE
refunds eto with transfer

### DIFF
--- a/contracts/ETO/ETOCommitment.sol
+++ b/contracts/ETO/ETOCommitment.sol
@@ -985,6 +985,7 @@ contract ETOCommitment is
         if (ticket.equivEurUlps == 0) {
             return;
         }
+        // modify state before sending
         ticket.claimOrRefundSettled = true;
 
         if (ticket.rewardNmkUlps > 0) {
@@ -1010,6 +1011,7 @@ contract ETOCommitment is
         if (ticket.equivEurUlps == 0) {
             return;
         }
+        //modify state before sending
         ticket.claimOrRefundSettled = true;
         refundSingleToken(investor, ticket.amountEth, ticket.usedLockedAccount, ETHER_LOCK, ETHER_TOKEN);
         refundSingleToken(investor, ticket.amountEurUlps, ticket.usedLockedAccount, EURO_LOCK, EURO_TOKEN);
@@ -1042,7 +1044,9 @@ contract ETOCommitment is
             }
         }
         if (a > 0) {
-            assert(token.transfer(investor, a, ""));
+            // use regular transfer, do not assume that if wallet contract was used
+            // it will implement ERC223
+            assert(token.transfer(investor, a));
         }
     }
 }

--- a/contracts/ETO/ETOTerms.sol
+++ b/contracts/ETO/ETOTerms.sol
@@ -18,7 +18,7 @@ import "../AccessRoles.sol";
 // 2 - whitelist management shifted from company to WHITELIST ADMIN
 // 3 - SHARE_NOMINAL_VALUE_EUR_ULPS, TOKEN_NAME, TOKEN_SYMBOL moved to ETOTokenTerms
 //     replaces EXISTING_COMPANY_SHARS with EXISTING_SHARE_CAPITAL, adds CURRENCY CODE
-// 4 - introduces
+//
 //     MAX_AVAILABLE_TOKENS with the actual amount of tokens for sale
 //     MAX_AVAILABLE_TOKENS_IN_WHITELIST with the actual amount of tokens for sale in whitelist
 //     ALLOWS_REGD_INVESTORS are US investors on reg-d allowed to participate in this ETO

--- a/migrations/deployETO.js
+++ b/migrations/deployETO.js
@@ -215,7 +215,7 @@ export async function checkETO(artifacts, config, etoCommitmentAddress, dumpCons
   console.log(`ETO Terms verified...${termsConstraintsVerified ? good("YES") : wrong("NO")}`);
   const etoContractId = await eto.contractId();
   console.log(`Contract id ${etoContractId[0]} version ${etoContractId[1].toNumber()}`);
-  // todo: show all ETO properties (state, tokens, dates, ETO terms, contribution, totals etc.)
+  // show all ETO properties (state, tokens, dates, ETO terms, contribution, totals etc.)
   console.log("------------------------------------------------------");
   const state = await eto.state();
   console.log("In state: ", ...good(CommitmentStateRev[state]));


### PR DESCRIPTION
we switch to regular ERC20 transfer in refund operation of ETOCommitment. ERC223 is not supported anywhere anymore it seems and using this will cause problem from smart contract based wallets like Gnosis Safe which do not implement required callbacks in their proxy contracts