### PR TITLE
parametrized equity token decimals

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           - v3-deps-{{ checksum "package.json" }}
           - v3-deps-
       - run: source /opt/circleci/.nvm/nvm.sh && yarn --production
-      - run: source /opt/circleci/.nvm/nvm.sh && yarn test
+      - run: source /opt/circleci/.nvm/nvm.sh && make tests
       - save_cache:
           paths:
             - node_modules

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,13 @@ test-container: container
 	$(MAKE) deploy
 	$(MAKE) down
 
+tests:
+	# default 18 decimal precision test
+	yarn test
+	# run eto tests with two precisions
+	EQUITY_TOKEN_PRECISION=0 yarn truffle test test/ETO/* test/setup.js --network inprocess_test
+	EQUITY_TOKEN_PRECISION=10 yarn truffle test test/ETO/* test/setup.js --network inprocess_test
+
 down:
 ifneq ($(shell docker ps -q -f NAME=^/platform-contracts$),)
 	-docker stop platform-contracts

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ test-container: container
 	$(MAKE) down
 
 tests:
-	# default 18 decimal precision test
+	# default 18 decimals test
 	yarn test
-	# run eto tests with two precisions
-	EQUITY_TOKEN_PRECISION=0 yarn truffle test test/ETO/* test/setup.js --network inprocess_test
-	EQUITY_TOKEN_PRECISION=10 yarn truffle test test/ETO/* test/setup.js --network inprocess_test
+	# run eto tests in two scales
+	EQUITY_TOKEN_DECIMALS=0 yarn truffle test test/ETO/* test/setup.js --network inprocess_test
+	EQUITY_TOKEN_DECIMALS=10 yarn truffle test test/ETO/* test/setup.js --network inprocess_test
 
 down:
 ifneq ($(shell docker ps -q -f NAME=^/platform-contracts$),)

--- a/contracts/Company/EquityToken.sol
+++ b/contracts/Company/EquityToken.sol
@@ -112,7 +112,7 @@ contract EquityToken is
         )
         TokenMetadata(
             etoTokenTerms.EQUITY_TOKEN_NAME(),
-            etoTokenTerms.EQUITY_TOKENS_PRECISION(),
+            etoTokenTerms.EQUITY_TOKEN_DECIMALS(),
             etoTokenTerms.EQUITY_TOKEN_SYMBOL(),
             "1.0"
         )

--- a/contracts/ETO/ETOCommitment.sol
+++ b/contracts/ETO/ETOCommitment.sol
@@ -48,7 +48,6 @@ contract ETOCommitment is
     struct InvestmentTicket {
         // euro equivalent of both currencies.
         //  for ether equivalent is generated per ETH/EUR spot price provided by ITokenExchangeRateOracle
-        // 128bit values 2**128 / 10**18 which is 340 quintillion 282 quadrillion 366 trillion 920 billion 938 million 463 thousand 463 nEUR max
         uint96 equivEurUlps;
         // NEU reward issued
         uint96 rewardNmkUlps;
@@ -127,6 +126,7 @@ contract ETOCommitment is
 
     // data below start at 32 bytes boundary and pack into two 32 bytes words
     // total investment in euro equivalent (ETH converted on spot prices)
+    // 128bit values 2**128 / 10**18 which is 340 quintillion 282 quadrillion 366 trillion 920 billion 938 million 463 thousand 463 nEUR max
     uint128 private _totalEquivEurUlps;
     // total equity tokens acquired
     uint128 private _totalTokenAmount;
@@ -134,16 +134,15 @@ contract ETOCommitment is
     uint128 private _totalFixedSlotsTokenAmount;
     // total investors that participated
     uint128 private _totalInvestors;
-
-    // nominee investment agreement url confirmation hash
-    bytes32 private _nomineeSignedInvestmentAgreementUrlHash;
-
     // additonal contribution / investment amount eth
     // it holds investment eth amount until end of public phase, then additional contribution
     uint128 private _additionalContributionEth;
     // additonal contribution / investment amount eur
     // it holds investment eur amount until end of public phase, then additional contribution
     uint128 private _additionalContributionEurUlps;
+
+    // nominee investment agreement url confirmation hash
+    bytes32 private _nomineeSignedInvestmentAgreementUrlHash;
 
     // successful ETO bookeeping
     // amount of new shares generated never exceeds number of tokens (uint128)

--- a/contracts/ETO/ETOTerms.sol
+++ b/contracts/ETO/ETOTerms.sol
@@ -220,6 +220,8 @@ contract ETOTerms is
         return proportion(tokenAmount, FULL_TOKEN_PRICE_FRACTION, EQUITY_TOKEN_POWER);
     }
 
+    // calculates a fraction `priceFrac` of the full token price, typically used for discounts
+    // returns new price as decimal fraction
     function calculatePriceFraction(uint256 priceFrac) public constant returns(uint256) {
         if (priceFrac == 1) {
             return TOKEN_PRICE_EUR_ULPS;

--- a/contracts/ETO/ETOTerms.sol
+++ b/contracts/ETO/ETOTerms.sol
@@ -100,15 +100,15 @@ contract ETOTerms is
     uint256 public MAX_AVAILABLE_TOKENS;
     // number of tokens that can be sold in whitelist
     uint256 public MAX_AVAILABLE_TOKENS_IN_WHITELIST;
-    // equity token scale power (10^precision)
+    // equity token scale power (10^decimals)
     uint256 public EQUITY_TOKEN_POWER;
 
     // base token price in EUR-T, without any discount scheme
     uint256 private TOKEN_PRICE_EUR_ULPS;
     // equity tokens per share
     uint256 private EQUITY_TOKENS_PER_SHARE;
-    // full price fraction
-    uint256 private FULL_PRICE_FRACTION;
+    // public-discounted price to be paid for a full token during the eto
+    uint256 private FULL_TOKEN_PRICE_FRACTION;
 
 
     ////////////////////////
@@ -186,11 +186,11 @@ contract ETOTerms is
         UNIVERSE = universe;
 
         // compute max available tokens to be sold in ETO
-        EQUITY_TOKEN_POWER = 10 ** uint256(tokenTerms.EQUITY_TOKENS_PRECISION());
+        EQUITY_TOKEN_POWER = 10 ** uint256(tokenTerms.EQUITY_TOKEN_DECIMALS());
         require(EQUITY_TOKEN_POWER <= 10 ** 18);
         MAX_AVAILABLE_TOKENS = calculateAvailableTokens(tokenTerms.MAX_NUMBER_OF_TOKENS());
         MAX_AVAILABLE_TOKENS_IN_WHITELIST = min(MAX_AVAILABLE_TOKENS, tokenTerms.MAX_NUMBER_OF_TOKENS_IN_WHITELIST());
-        FULL_PRICE_FRACTION = calculatePriceFraction(10**18 - PUBLIC_DISCOUNT_FRAC);
+        FULL_TOKEN_PRICE_FRACTION = calculatePriceFraction(10**18 - PUBLIC_DISCOUNT_FRAC);
 
         // validate all settings
         requireValidTerms();
@@ -201,25 +201,23 @@ contract ETOTerms is
     ////////////////////////
 
     // calculates token amount for a given commitment at a position of the curve
-    // we require that equity token precision is 0
     function calculateTokenAmount(uint256 /*totalEurUlps*/, uint256 committedEurUlps)
         public
         constant
         returns (uint256 tokenAmount)
     {
         // we may disregard totalEurUlps as curve is flat, round down when calculating tokens
-        return mul(committedEurUlps, EQUITY_TOKEN_POWER) / FULL_PRICE_FRACTION;
+        return mul(committedEurUlps, EQUITY_TOKEN_POWER) / FULL_TOKEN_PRICE_FRACTION;
     }
 
     // calculates amount of euro required to acquire amount of tokens at a position of the (inverse) curve
-    // we require that equity token precision is 0
     function calculateEurUlpsAmount(uint256 /*totalTokenAmount*/, uint256 tokenAmount)
         public
         constant
         returns (uint256 committedEurUlps)
     {
         // we may disregard totalTokenAmount as curve is flat
-        return proportion(tokenAmount, FULL_PRICE_FRACTION, EQUITY_TOKEN_POWER);
+        return proportion(tokenAmount, FULL_TOKEN_PRICE_FRACTION, EQUITY_TOKEN_POWER);
     }
 
     function calculatePriceFraction(uint256 priceFrac) public constant returns(uint256) {
@@ -230,7 +228,8 @@ contract ETOTerms is
         }
     }
 
-    // calculate effective price of the token based on actual amounts
+    // calculates price of a token by dividing amountEurUlps by equityTokenAmount and scaling to 10**18
+    // note that all prices are decimal fractions as defined in Math.sol
     function calculateTokenEurPrice(uint256 amountEurUlps, uint256 equityTokenAmount) public constant returns(uint256) {
         return proportion(amountEurUlps, EQUITY_TOKEN_POWER, equityTokenAmount);
     }
@@ -409,7 +408,7 @@ contract ETOTerms is
                     uint256 fixedSlotPrice = calculatePriceFraction(wlTicket.fullTokenPriceFrac);
                     fixedSlotEquityTokenAmount = mul(discountedAmount, EQUITY_TOKEN_POWER) / fixedSlotPrice;
                     // calculate the really spent part to cover for rounding errors in next tranche (remainingAmount)
-                    // commented out as with 18 digit precision we have 1 wei difference max and we'll not deploy any other
+                    // commented out as with 18 digit scale we have 1 wei difference max and we'll not deploy any other
                     // precisions anymore
                     // discountedAmount = fixedSlotEquityTokenAmount * fixedSlotPrice / EQUITY_TOKEN_POWER;
                 }

--- a/contracts/ETO/ETOTokenTerms.sol
+++ b/contracts/ETO/ETOTokenTerms.sol
@@ -6,6 +6,7 @@ import "../Standards/IContractId.sol";
 // version history as per contract id
 // 0 - initial version
 // 1 - added SHARE_NOMINAL_VALUE_ULPS, SHARE_NOMINAL_VALUE_EUR_ULPS, TOKEN_NAME, TOKEN_SYMBOL, SHARE_PRICE
+// 2 - renamed EQUITY_TOKEN_PRECISION to EQUITY_TOKEN_DECIMALS
 
 
 /// @title sets terms for tokens in ETO
@@ -108,6 +109,6 @@ contract ETOTokenTerms is Math, IContractId {
     //
 
     function contractId() public pure returns (bytes32 id, uint256 version) {
-        return (0x591e791aab2b14c80194b729a2abcba3e8cce1918be4061be170e7223357ae5c, 1);
+        return (0x591e791aab2b14c80194b729a2abcba3e8cce1918be4061be170e7223357ae5c, 2);
     }
 }

--- a/contracts/ETO/ETOTokenTerms.sol
+++ b/contracts/ETO/ETOTokenTerms.sol
@@ -41,7 +41,7 @@ contract ETOTokenTerms is Math, IContractId {
     // equity tokens per share
     uint256 public EQUITY_TOKENS_PER_SHARE;
     // equity tokens decimals (precision)
-    uint8 public EQUITY_TOKENS_PRECISION;
+    uint8 public EQUITY_TOKEN_DECIMALS;
 
     // scale power of equity token (10**decimals)
     uint256 private EQUITY_TOKENS_POWER;
@@ -61,7 +61,7 @@ contract ETOTokenTerms is Math, IContractId {
         uint256 shareNominalValueUlps,
         uint256 shareNominalValueEurUlps,
         uint256 equityTokensPerShare,
-        uint8 equityTokensPrecision
+        uint8 equityTokenDecimals
     )
         public
     {
@@ -88,10 +88,10 @@ contract ETOTokenTerms is Math, IContractId {
         EQUITY_TOKEN_NAME = equityTokenName;
         EQUITY_TOKEN_SYMBOL = equityTokenSymbol;
         EQUITY_TOKENS_PER_SHARE = equityTokensPerShare;
-        EQUITY_TOKENS_PRECISION = equityTokensPrecision;
-        EQUITY_TOKENS_POWER = 10**uint256(EQUITY_TOKENS_PRECISION);
+        EQUITY_TOKEN_DECIMALS = equityTokenDecimals;
+        EQUITY_TOKENS_POWER = 10**uint256(EQUITY_TOKEN_DECIMALS);
 
-        require(equityTokensPerShare >= 0 && equityTokensPerShare % EQUITY_TOKENS_POWER == 0, "NF_SHARES_NOT_WHOLE_TOKENS");
+        require(equityTokensPerShare > 0 && equityTokensPerShare % EQUITY_TOKENS_POWER == 0, "NF_SHARES_NOT_WHOLE_TOKENS");
         require(proportion(tokenPriceEurUlps, maxNumberOfTokens, EQUITY_TOKENS_POWER) < 2**112, "NF_TOO_MUCH_FUNDS_COLLECTED");
     }
 

--- a/contracts/ETO/ETOTokenTerms.sol
+++ b/contracts/ETO/ETOTokenTerms.sol
@@ -40,7 +40,7 @@ contract ETOTokenTerms is Math, IContractId {
     uint256 public SHARE_NOMINAL_VALUE_EUR_ULPS;
     // equity tokens per share
     uint256 public EQUITY_TOKENS_PER_SHARE;
-    // equity tokens decimals (precision)
+    // equity tokens decimals (scale)
     uint8 public EQUITY_TOKEN_DECIMALS;
 
     // scale power of equity token (10**decimals)

--- a/contracts/PlatformTerms.sol
+++ b/contracts/PlatformTerms.sol
@@ -58,7 +58,6 @@ contract PlatformTerms is Math, IContractId {
         pure
         returns (uint256)
     {
-        // mind tokens having 0 precision
         // x*0.02 == x/50
         return divRound(tokenAmount, 50);
     }

--- a/contracts/test/ETO/MockETOCommitment.sol
+++ b/contracts/test/ETO/MockETOCommitment.sol
@@ -72,4 +72,14 @@ contract MockETOCommitment is
         emit LogTermsSet(msg.sender, address(etoTerms), address(equityToken));
         emit LogETOStartDateSet(msg.sender, startAt, logStartDate);
     }
+
+    //
+    // Override IAgreement internal interface to allow mocking up agreements for fixtures
+    //
+    function mCanAmend(address /*legalRepresentative*/)
+        internal
+        returns (bool)
+    {
+        return true;
+    }
 }

--- a/contracts/test/ETO/MockUncheckedETOTokenTerms.sol
+++ b/contracts/test/ETO/MockUncheckedETOTokenTerms.sol
@@ -20,7 +20,8 @@ contract MockUncheckedETOTokenTerms is ETOTokenTerms {
         uint256 maxNumberOfTokensInWhitelist,
         uint256 shareNominalValueUlps,
         uint256 shareNominalValueEurUlps,
-        uint256 equityTokensPerShare
+        uint256 equityTokensPerShare,
+        uint8 equityTokensPrecision
     )
         public
         // do not pass max, min ticket etc. to disable overflow checks
@@ -33,7 +34,8 @@ contract MockUncheckedETOTokenTerms is ETOTokenTerms {
             equityTokensPerShare,
             shareNominalValueUlps,
             shareNominalValueEurUlps,
-            equityTokensPerShare
+            equityTokensPerShare,
+            equityTokensPrecision
         )
     {
         require(maxNumberOfTokensInWhitelist <= maxNumberOfTokens, "NF_WL_TOKENS_GT_MAX_TOKENS");
@@ -46,5 +48,6 @@ contract MockUncheckedETOTokenTerms is ETOTokenTerms {
         TOKEN_PRICE_EUR_ULPS = tokenPriceEurUlps;
         MAX_NUMBER_OF_TOKENS_IN_WHITELIST = maxNumberOfTokensInWhitelist;
         EQUITY_TOKENS_PER_SHARE = equityTokensPerShare;
+
     }
 }

--- a/contracts/test/ETO/MockUncheckedETOTokenTerms.sol
+++ b/contracts/test/ETO/MockUncheckedETOTokenTerms.sol
@@ -48,6 +48,5 @@ contract MockUncheckedETOTokenTerms is ETOTokenTerms {
         TOKEN_PRICE_EUR_ULPS = tokenPriceEurUlps;
         MAX_NUMBER_OF_TOKENS_IN_WHITELIST = maxNumberOfTokensInWhitelist;
         EQUITY_TOKENS_PER_SHARE = equityTokensPerShare;
-
     }
 }

--- a/contracts/test/ETO/MockUncheckedETOTokenTerms.sol
+++ b/contracts/test/ETO/MockUncheckedETOTokenTerms.sol
@@ -21,7 +21,7 @@ contract MockUncheckedETOTokenTerms is ETOTokenTerms {
         uint256 shareNominalValueUlps,
         uint256 shareNominalValueEurUlps,
         uint256 equityTokensPerShare,
-        uint8 equityTokensPrecision
+        uint8 equityTokenDecimals
     )
         public
         // do not pass max, min ticket etc. to disable overflow checks
@@ -35,7 +35,7 @@ contract MockUncheckedETOTokenTerms is ETOTokenTerms {
             shareNominalValueUlps,
             shareNominalValueEurUlps,
             equityTokensPerShare,
-            equityTokensPrecision
+            equityTokenDecimals
         )
     {
         require(maxNumberOfTokensInWhitelist <= maxNumberOfTokens, "NF_WL_TOKENS_GT_MAX_TOKENS");

--- a/migrations/106_deploy_fixture_commitments.js
+++ b/migrations/106_deploy_fixture_commitments.js
@@ -412,7 +412,7 @@ async function simulateETO(DEPLOYER, CONFIG, universe, nominee, issuer, etoDefin
   }
   console.log("Going to signing");
   // we must invest minimum value
-  const tokenPower = decimalBase.pow(etoDefiniton.tokenTerms.EQUITY_TOKENS_PRECISION);
+  const tokenPower = decimalBase.pow(etoDefiniton.tokenTerms.EQUITY_TOKEN_DECIMALS);
   const amountMinTokensEur = etoDefiniton.tokenTerms.MIN_NUMBER_OF_TOKENS.mul(
     etoDefiniton.tokenTerms.TOKEN_PRICE_EUR_ULPS,
   ).divToInt(tokenPower);

--- a/migrations/configETOFixtures.js
+++ b/migrations/configETOFixtures.js
@@ -1,7 +1,21 @@
-import { web3, Q18, daysToSeconds, recoverBigNumbers } from "../test/helpers/constants";
+import {
+  web3,
+  decimalBase,
+  Q18,
+  daysToSeconds,
+  recoverBigNumbers,
+} from "../test/helpers/constants";
 
 const getETOConstraintFixtureAndAddressByName = require("./configETOTermsFixtures")
   .getFixtureAndAddressByName;
+
+// standard 18 decimals precision
+export const stdEquityTokenPrecision = new web3.BigNumber("0");
+export const stdEquityTokenPower = decimalBase.pow(stdEquityTokenPrecision);
+
+// legacy (indivisible) token precision and power
+const indivisibleEquityTokenPrecision = new web3.BigNumber("0");
+const indivisibleEquityTokenPower = decimalBase.pow(indivisibleEquityTokenPrecision);
 
 export const defEtoTerms = {
   shareholderTerms: {
@@ -25,13 +39,14 @@ export const defEtoTerms = {
   tokenTerms: {
     EQUITY_TOKEN_NAME: "Quintessence",
     EQUITY_TOKEN_SYMBOL: "QTT",
-    MIN_NUMBER_OF_TOKENS: new web3.BigNumber(1000 * 10000),
-    MAX_NUMBER_OF_TOKENS: new web3.BigNumber(3452 * 10000),
+    MIN_NUMBER_OF_TOKENS: stdEquityTokenPower.mul(1000 * 10000),
+    MAX_NUMBER_OF_TOKENS: stdEquityTokenPower.mul(3452 * 10000),
     TOKEN_PRICE_EUR_ULPS: Q18.mul("0.32376189"),
-    MAX_NUMBER_OF_TOKENS_IN_WHITELIST: new web3.BigNumber(1534 * 10000),
+    MAX_NUMBER_OF_TOKENS_IN_WHITELIST: stdEquityTokenPower.mul(1534 * 10000),
     SHARE_NOMINAL_VALUE_ULPS: Q18,
     SHARE_NOMINAL_VALUE_EUR_ULPS: Q18,
-    EQUITY_TOKENS_PER_SHARE: new web3.BigNumber("10000"),
+    EQUITY_TOKENS_PER_SHARE: stdEquityTokenPower.mul("10000"),
+    EQUITY_TOKENS_PRECISION: stdEquityTokenPrecision,
   },
   etoTerms: {
     DURATION_TERMS: null,
@@ -73,13 +88,14 @@ export const hnwiEtoDeSecurityTerms = {
   tokenTerms: {
     EQUITY_TOKEN_NAME: "Rich",
     EQUITY_TOKEN_SYMBOL: "RCH",
-    MIN_NUMBER_OF_TOKENS: new web3.BigNumber(1000 * 10000),
-    MAX_NUMBER_OF_TOKENS: new web3.BigNumber(3452 * 10000),
+    MIN_NUMBER_OF_TOKENS: indivisibleEquityTokenPower.mul(1000 * 10000),
+    MAX_NUMBER_OF_TOKENS: indivisibleEquityTokenPower.mul(3452 * 10000),
     TOKEN_PRICE_EUR_ULPS: Q18.mul("0.42376189"),
-    MAX_NUMBER_OF_TOKENS_IN_WHITELIST: new web3.BigNumber(1534 * 10000),
+    MAX_NUMBER_OF_TOKENS_IN_WHITELIST: indivisibleEquityTokenPower.mul(1534 * 10000),
     SHARE_NOMINAL_VALUE_ULPS: Q18,
     SHARE_NOMINAL_VALUE_EUR_ULPS: Q18,
-    EQUITY_TOKENS_PER_SHARE: new web3.BigNumber("10000"),
+    EQUITY_TOKENS_PER_SHARE: indivisibleEquityTokenPower.mul("10000"),
+    EQUITY_TOKENS_PRECISION: indivisibleEquityTokenPrecision,
   },
   etoTerms: {
     ETO_TERMS_CONSTRAINTS: null,
@@ -132,13 +148,14 @@ export const retailEtoDeVmaTerms = {
   tokenTerms: {
     EQUITY_TOKEN_NAME: "NOMERA",
     EQUITY_TOKEN_SYMBOL: "NOM",
-    MIN_NUMBER_OF_TOKENS: "10000000",
-    MAX_NUMBER_OF_TOKENS: "15000000",
+    MIN_NUMBER_OF_TOKENS: stdEquityTokenPower.mul("10000000"),
+    MAX_NUMBER_OF_TOKENS: stdEquityTokenPower.mul("15000000"),
     TOKEN_PRICE_EUR_ULPS: "666666666666666667",
-    MAX_NUMBER_OF_TOKENS_IN_WHITELIST: "15000000",
+    MAX_NUMBER_OF_TOKENS_IN_WHITELIST: stdEquityTokenPower.mul("15000000"),
     SHARE_NOMINAL_VALUE_ULPS: "1000000000000000000",
     SHARE_NOMINAL_VALUE_EUR_ULPS: "1000000000000000000",
-    EQUITY_TOKENS_PER_SHARE: new web3.BigNumber("10000"),
+    EQUITY_TOKENS_PER_SHARE: stdEquityTokenPower.mul("10000"),
+    EQUITY_TOKENS_PRECISION: stdEquityTokenPrecision,
   },
   etoTermsConstraints: "retail eto de vma",
   reservationAndAcquisitionAgreement: "ipfs:QmQsmERwxd9p4njM91aaT5nVhF6q1G3V35JYAzpvFMKrxp",
@@ -177,13 +194,14 @@ export const miniEtoLiTerms = {
   tokenTerms: {
     EQUITY_TOKEN_NAME: "Blok",
     EQUITY_TOKEN_SYMBOL: "BLKK",
-    MIN_NUMBER_OF_TOKENS: "5000000",
-    MAX_NUMBER_OF_TOKENS: "6000000",
+    MIN_NUMBER_OF_TOKENS: stdEquityTokenPower.mul("5000000"),
+    MAX_NUMBER_OF_TOKENS: stdEquityTokenPower.mul("6000000"),
     TOKEN_PRICE_EUR_ULPS: "600000000000000000",
-    MAX_NUMBER_OF_TOKENS_IN_WHITELIST: "5500000",
+    MAX_NUMBER_OF_TOKENS_IN_WHITELIST: stdEquityTokenPower.mul("5500000"),
     SHARE_NOMINAL_VALUE_ULPS: "1000000000000000000",
     SHARE_NOMINAL_VALUE_EUR_ULPS: "1000000000000000000",
-    EQUITY_TOKENS_PER_SHARE: new web3.BigNumber("10000"),
+    EQUITY_TOKENS_PER_SHARE: stdEquityTokenPower.mul("10000"),
+    EQUITY_TOKENS_PRECISION: stdEquityTokenPrecision,
   },
   etoTermsConstraints: "mini eto li",
   reservationAndAcquisitionAgreement: "ipfs:QmQsmERwxd9p4njM91aaT5nVhF6q1G3V35JYAzpvFMKrxp",
@@ -222,13 +240,14 @@ export const miniEtoLiNominalValueTerms = {
   tokenTerms: {
     EQUITY_TOKEN_NAME: "6-SHARES",
     EQUITY_TOKEN_SYMBOL: "SSH",
-    MIN_NUMBER_OF_TOKENS: "6000000",
-    MAX_NUMBER_OF_TOKENS: "30000000",
+    MIN_NUMBER_OF_TOKENS: indivisibleEquityTokenPower.mul("6000000"),
+    MAX_NUMBER_OF_TOKENS: indivisibleEquityTokenPower.mul("30000000"),
     TOKEN_PRICE_EUR_ULPS: Q18.mul("0.161870503597122302"),
-    MAX_NUMBER_OF_TOKENS_IN_WHITELIST: "30000000",
+    MAX_NUMBER_OF_TOKENS_IN_WHITELIST: indivisibleEquityTokenPower.mul("30000000"),
     SHARE_NOMINAL_VALUE_ULPS: Q18.mul("100"),
     SHARE_NOMINAL_VALUE_EUR_ULPS: Q18.mul("13.5"),
-    EQUITY_TOKENS_PER_SHARE: new web3.BigNumber("1000000"),
+    EQUITY_TOKENS_PER_SHARE: indivisibleEquityTokenPower.mul("1000000"),
+    EQUITY_TOKENS_PRECISION: indivisibleEquityTokenPrecision,
   },
   etoTermsConstraints: "mini eto li",
   reservationAndAcquisitionAgreement: "ipfs:QmQsmERwxd9p4njM91aaT5nVhF6q1G3V35JYAzpvFMKrxp",
@@ -267,13 +286,14 @@ export const hnwiEtoLiSecurityTerms = {
   tokenTerms: {
     EQUITY_TOKEN_NAME: "Bionic",
     EQUITY_TOKEN_SYMBOL: "BNIC",
-    MIN_NUMBER_OF_TOKENS: "10000000",
-    MAX_NUMBER_OF_TOKENS: "20000000",
+    MIN_NUMBER_OF_TOKENS: stdEquityTokenPower.mul("10000000"),
+    MAX_NUMBER_OF_TOKENS: stdEquityTokenPower.mul("20000000"),
     TOKEN_PRICE_EUR_ULPS: "796019900497512438",
-    MAX_NUMBER_OF_TOKENS_IN_WHITELIST: "20000000",
+    MAX_NUMBER_OF_TOKENS_IN_WHITELIST: stdEquityTokenPower.mul("20000000"),
     SHARE_NOMINAL_VALUE_ULPS: "1000000000000000000",
     SHARE_NOMINAL_VALUE_EUR_ULPS: "1000000000000000000",
-    EQUITY_TOKENS_PER_SHARE: new web3.BigNumber("10000"),
+    EQUITY_TOKENS_PER_SHARE: stdEquityTokenPower.mul("10000"),
+    EQUITY_TOKENS_PRECISION: stdEquityTokenPrecision,
   },
   etoTermsConstraints: "hnwi eto li security",
   reservationAndAcquisitionAgreement: "ipfs:QmQsmERwxd9p4njM91aaT5nVhF6q1G3V35JYAzpvFMKrxp",
@@ -312,13 +332,14 @@ export const retailSMEEtoLi = {
   tokenTerms: {
     EQUITY_TOKEN_NAME: "Quintessence",
     EQUITY_TOKEN_SYMBOL: "QTT",
-    MIN_NUMBER_OF_TOKENS: new web3.BigNumber(1000 * 10000),
-    MAX_NUMBER_OF_TOKENS: new web3.BigNumber(3452 * 10000),
+    MIN_NUMBER_OF_TOKENS: stdEquityTokenPower.mul(1000 * 10000),
+    MAX_NUMBER_OF_TOKENS: stdEquityTokenPower.mul(3452 * 10000),
     TOKEN_PRICE_EUR_ULPS: Q18.mul("0.32376189"),
-    MAX_NUMBER_OF_TOKENS_IN_WHITELIST: new web3.BigNumber(1534 * 10000),
+    MAX_NUMBER_OF_TOKENS_IN_WHITELIST: stdEquityTokenPower.mul(1534 * 10000),
     SHARE_NOMINAL_VALUE_ULPS: Q18,
     SHARE_NOMINAL_VALUE_EUR_ULPS: Q18,
-    EQUITY_TOKENS_PER_SHARE: new web3.BigNumber("10000"),
+    EQUITY_TOKENS_PER_SHARE: stdEquityTokenPower.mul("10000"),
+    EQUITY_TOKENS_PRECISION: stdEquityTokenPrecision,
   },
   etoTermsConstraints: "retail EU-SME eto li security",
   reservationAndAcquisitionAgreement: "ipfs:QmQsmERwxd9p4njM91aaT5nVhF6q1G3V35JYAzpvFMKrxp",

--- a/migrations/configETOFixtures.js
+++ b/migrations/configETOFixtures.js
@@ -26,8 +26,8 @@ export const defEtoTerms = {
     GENERAL_VOTING_DURATION: new web3.BigNumber(daysToSeconds(10)),
     RESTRICTED_ACT_VOTING_DURATION: new web3.BigNumber(daysToSeconds(14)),
     VOTING_FINALIZATION_DURATION: new web3.BigNumber(daysToSeconds(5)),
-    SHAREHOLDERS_VOTING_QUORUM_FRAC: Q18.mul(0.5),
-    VOTING_MAJORITY_FRAC: Q18.mul(0.5),
+    SHAREHOLDERS_VOTING_QUORUM_FRAC: Q18.mul("0.5"),
+    VOTING_MAJORITY_FRAC: Q18.mul("0.5"),
     INVESTMENT_AGREEMENT_TEMPLATE_URL: "ipfs:QmNPyPao7dEsQzKarCYCyGyDrutzWyACDMcq8HbQ1eGt2E",
   },
   durTerms: {

--- a/migrations/configETOFixtures.js
+++ b/migrations/configETOFixtures.js
@@ -9,13 +9,13 @@ import {
 const getETOConstraintFixtureAndAddressByName = require("./configETOTermsFixtures")
   .getFixtureAndAddressByName;
 
-// standard 18 decimals precision
-export const stdEquityTokenPrecision = new web3.BigNumber("0");
-export const stdEquityTokenPower = decimalBase.pow(stdEquityTokenPrecision);
+// standard 18 decimals scale
+export const stdEquityTokenDecimals = new web3.BigNumber("0");
+export const stdEquityTokenPower = decimalBase.pow(stdEquityTokenDecimals);
 
-// legacy (indivisible) token precision and power
-const indivisibleEquityTokenPrecision = new web3.BigNumber("0");
-const indivisibleEquityTokenPower = decimalBase.pow(indivisibleEquityTokenPrecision);
+// legacy (indivisible) token scale and power
+const indivisibleEquityTokenDecimals = new web3.BigNumber("0");
+const indivisibleEquityTokenPower = decimalBase.pow(indivisibleEquityTokenDecimals);
 
 export const defEtoTerms = {
   shareholderTerms: {
@@ -46,7 +46,7 @@ export const defEtoTerms = {
     SHARE_NOMINAL_VALUE_ULPS: Q18,
     SHARE_NOMINAL_VALUE_EUR_ULPS: Q18,
     EQUITY_TOKENS_PER_SHARE: stdEquityTokenPower.mul("10000"),
-    EQUITY_TOKENS_PRECISION: stdEquityTokenPrecision,
+    EQUITY_TOKEN_DECIMALS: stdEquityTokenDecimals,
   },
   etoTerms: {
     DURATION_TERMS: null,
@@ -95,7 +95,7 @@ export const hnwiEtoDeSecurityTerms = {
     SHARE_NOMINAL_VALUE_ULPS: Q18,
     SHARE_NOMINAL_VALUE_EUR_ULPS: Q18,
     EQUITY_TOKENS_PER_SHARE: indivisibleEquityTokenPower.mul("10000"),
-    EQUITY_TOKENS_PRECISION: indivisibleEquityTokenPrecision,
+    EQUITY_TOKEN_DECIMALS: indivisibleEquityTokenDecimals,
   },
   etoTerms: {
     ETO_TERMS_CONSTRAINTS: null,
@@ -155,7 +155,7 @@ export const retailEtoDeVmaTerms = {
     SHARE_NOMINAL_VALUE_ULPS: "1000000000000000000",
     SHARE_NOMINAL_VALUE_EUR_ULPS: "1000000000000000000",
     EQUITY_TOKENS_PER_SHARE: stdEquityTokenPower.mul("10000"),
-    EQUITY_TOKENS_PRECISION: stdEquityTokenPrecision,
+    EQUITY_TOKEN_DECIMALS: stdEquityTokenDecimals,
   },
   etoTermsConstraints: "retail eto de vma",
   reservationAndAcquisitionAgreement: "ipfs:QmQsmERwxd9p4njM91aaT5nVhF6q1G3V35JYAzpvFMKrxp",
@@ -201,7 +201,7 @@ export const miniEtoLiTerms = {
     SHARE_NOMINAL_VALUE_ULPS: "1000000000000000000",
     SHARE_NOMINAL_VALUE_EUR_ULPS: "1000000000000000000",
     EQUITY_TOKENS_PER_SHARE: stdEquityTokenPower.mul("10000"),
-    EQUITY_TOKENS_PRECISION: stdEquityTokenPrecision,
+    EQUITY_TOKEN_DECIMALS: stdEquityTokenDecimals,
   },
   etoTermsConstraints: "mini eto li",
   reservationAndAcquisitionAgreement: "ipfs:QmQsmERwxd9p4njM91aaT5nVhF6q1G3V35JYAzpvFMKrxp",
@@ -247,7 +247,7 @@ export const miniEtoLiNominalValueTerms = {
     SHARE_NOMINAL_VALUE_ULPS: Q18.mul("100"),
     SHARE_NOMINAL_VALUE_EUR_ULPS: Q18.mul("13.5"),
     EQUITY_TOKENS_PER_SHARE: indivisibleEquityTokenPower.mul("1000000"),
-    EQUITY_TOKENS_PRECISION: indivisibleEquityTokenPrecision,
+    EQUITY_TOKEN_DECIMALS: indivisibleEquityTokenDecimals,
   },
   etoTermsConstraints: "mini eto li",
   reservationAndAcquisitionAgreement: "ipfs:QmQsmERwxd9p4njM91aaT5nVhF6q1G3V35JYAzpvFMKrxp",
@@ -293,7 +293,7 @@ export const hnwiEtoLiSecurityTerms = {
     SHARE_NOMINAL_VALUE_ULPS: "1000000000000000000",
     SHARE_NOMINAL_VALUE_EUR_ULPS: "1000000000000000000",
     EQUITY_TOKENS_PER_SHARE: stdEquityTokenPower.mul("10000"),
-    EQUITY_TOKENS_PRECISION: stdEquityTokenPrecision,
+    EQUITY_TOKEN_DECIMALS: stdEquityTokenDecimals,
   },
   etoTermsConstraints: "hnwi eto li security",
   reservationAndAcquisitionAgreement: "ipfs:QmQsmERwxd9p4njM91aaT5nVhF6q1G3V35JYAzpvFMKrxp",
@@ -339,7 +339,7 @@ export const retailSMEEtoLi = {
     SHARE_NOMINAL_VALUE_ULPS: Q18,
     SHARE_NOMINAL_VALUE_EUR_ULPS: Q18,
     EQUITY_TOKENS_PER_SHARE: stdEquityTokenPower.mul("10000"),
-    EQUITY_TOKENS_PRECISION: stdEquityTokenPrecision,
+    EQUITY_TOKEN_DECIMALS: stdEquityTokenDecimals,
   },
   etoTermsConstraints: "retail EU-SME eto li security",
   reservationAndAcquisitionAgreement: "ipfs:QmQsmERwxd9p4njM91aaT5nVhF6q1G3V35JYAzpvFMKrxp",

--- a/test/ETO/ETOCommitment.js
+++ b/test/ETO/ETOCommitment.js
@@ -444,7 +444,20 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       // token price increased twice
       const i1ticket = await etoCommitment.investorTicket(investors[1]);
       const i2ticket = await etoCommitment.investorTicket(investors[2]);
-      expect(i1ticket[2].mul(2)).to.be.bignumber.eq(i2ticket[2]);
+      // but it does not mean that previous ticket amount is doubled due to rounding once, not twice
+      // i1ticket[2].mul(2) != i2ticket[2]
+      expect(
+        i1ticket[2]
+          .mul(2)
+          .sub(i2ticket[2])
+          .abs(),
+      ).to.be.bignumber.lt(2);
+      // this works because we set 1 eth == 2 eur
+      const tokensI2 = ticket
+        .mul(2)
+        .mul(getTokenPower())
+        .divToInt(tokenprice);
+      expect(i2ticket[2]).to.be.bignumber.eq(tokensI2);
     });
 
     it("reject if ETH price feed outdated", async () => {

--- a/test/ETO/ETOCommitment.js
+++ b/test/ETO/ETOCommitment.js
@@ -34,12 +34,15 @@ import { TriState } from "../helpers/triState";
 import { deserializeClaims } from "../helpers/identityClaims";
 import {
   ZERO_ADDRESS,
+  decimalBase,
   Q18,
   dayInSeconds,
   toBytes32,
   contractId,
   monthInSeconds,
   web3,
+  defEquityTokenPower,
+  defEquityTokenPrecision,
 } from "../helpers/constants";
 import { expectLogFundsCommitted } from "../helpers/commitment";
 import EvmError from "../helpers/EVMThrow";
@@ -58,6 +61,10 @@ const ETODurationTerms = artifacts.require("ETODurationTerms");
 const ShareholderRights = artifacts.require("ShareholderRights");
 const TestFeeDistributionPool = artifacts.require("TestFeeDistributionPool");
 
+// in a few places we use linear approximations and we require high precision
+// all other big numbers are integers
+web3.BigNumber.config({ DECIMAL_PLACES: 100 });
+
 const PLATFORM_SHARE = web3.toBigNumber("2");
 const minDepositAmountEurUlps = Q18.mul(50);
 const minWithdrawAmountEurUlps = Q18.mul(20);
@@ -67,8 +74,13 @@ const defEthPrice = web3.toBigNumber("657.39278932");
 const UNKNOWN_STATE_START_TS = 10000000; // state startOf timeestamps invalid below this
 const platformShare = nmk => nmk.div(PLATFORM_SHARE).round(0, 1); // round down
 const investorShare = nmk => nmk.sub(platformShare(nmk));
-const manyTokens = new web3.BigNumber(2).pow(32).sub(1);
+const manyTokens = new web3.BigNumber(2)
+  .pow(32)
+  .mul(defEquityTokenPower)
+  .sub(1);
 const inverseTokenFeeDec = defaultPlatformTerms.TOKEN_PARTICIPATION_FEE_FRACTION.div(Q18).add("1");
+const two = new web3.BigNumber(2);
+const one = new web3.BigNumber(1);
 
 contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
   // basic infrastructure
@@ -270,12 +282,12 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
     });
 
     it("rejects re-setting start date if now is less than DATE_TO_WHITELIST_MIN_DURATION to previous start date", async () => {
-      startDate = new web3.BigNumber(await latestTimestamp()).add(1);
+      startDate = new web3.BigNumber(await latestTimestamp()).add(3);
       startDate = startDate.add(await etoTermsConstraints.DATE_TO_WHITELIST_MIN_DURATION());
       await etoCommitment.setStartDate(etoTerms.address, equityToken.address, startDate, {
         from: company,
       });
-      await increaseTime(2);
+      await increaseTime(5);
       // now we are already too close to previously set date, dany change
       await expect(
         etoCommitment.setStartDate(
@@ -301,7 +313,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
     });
 
     it("rejects setting date before block.timestamp", async () => {
-      startDate = new web3.BigNumber(await latestTimestamp()).add(1);
+      startDate = new web3.BigNumber(await latestTimestamp()).add(3);
       startDate = startDate.add(await etoTermsConstraints.DATE_TO_WHITELIST_MIN_DURATION()).add(1);
       await etoCommitment.setStartDate(etoTerms.address, equityToken.address, startDate, {
         from: company,
@@ -320,7 +332,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
 
     it("rejects setting agreement by nominee when start date is set", async () => {
       await etoCommitment.amendAgreement("ABBA", { from: nominee });
-      startDate = new web3.BigNumber(await latestTimestamp()).add(1);
+      startDate = new web3.BigNumber(await latestTimestamp()).add(3);
       startDate = startDate.add(await etoTermsConstraints.DATE_TO_WHITELIST_MIN_DURATION());
       await etoCommitment.setStartDate(etoTerms.address, equityToken.address, startDate, {
         from: company,
@@ -416,10 +428,15 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
 
     it("with changing ether price during ETO", async () => {
       await skipTimeTo(publicStartDate.add(1));
+      // set some round ETH price to minimize rounding errors in the contract
+      await gasExchange.setExchangeRate(etherToken.address, euroToken.address, Q18, {
+        from: admin,
+      });
       const tokenprice = tokenTermsDict.TOKEN_PRICE_EUR_ULPS;
-      const ticket = Q18.mul(107.61721).add(1);
+      const ticket = Q18.mul("1070.61721").add(1);
       await investAmount(investors[1], ticket, "ETH", tokenprice);
-      const newPrice = Q18.mul(defEthPrice.mul(2));
+      // set double price
+      const newPrice = Q18.mul(2);
       await gasExchange.setExchangeRate(etherToken.address, euroToken.address, newPrice, {
         from: admin,
       });
@@ -522,6 +539,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
     it("should invest below min ticket if already invested min ticket", async () => {
       await skipTimeTo(publicStartDate.add(1));
       await investAmount(investors[0], etoTermsDict.MIN_TICKET_EUR_ULPS, "EUR");
+      // at least one token can be bought
       await investAmount(investors[0], tokenTermsDict.TOKEN_PRICE_EUR_ULPS, "EUR");
       // cannot invest less than token price
       await expect(
@@ -601,7 +619,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       // we must cross MIN CAP
       if (tokenTermsDict.MIN_NUMBER_OF_TOKENS.gt(totalInvestment[1])) {
         const missingTokens = tokenTermsDict.MIN_NUMBER_OF_TOKENS.sub(totalInvestment[1]);
-        let missingAmount = missingTokens.mul(tokenTermsDict.TOKEN_PRICE_EUR_ULPS);
+        let missingAmount = tokensCostEur(missingTokens, tokenTermsDict.TOKEN_PRICE_EUR_ULPS);
         if (missingAmount.lt(etoTermsDict.MIN_TICKET_EUR_ULPS)) {
           missingAmount = etoTermsDict.MIN_TICKET_EUR_ULPS;
         }
@@ -623,14 +641,12 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       );
       // this is also state transition into claim
       expect(await etoCommitment.state()).to.be.bignumber.eq(CommitmentState.Claim);
-      expectValidClaimState(nomineeSignTx, contribution);
+      await expectValidClaimState(nomineeSignTx, contribution);
     });
 
     it("go from public to signing by reaching max cap exactly (max tokens)", async () => {
       await skipTimeTo(publicStartDate.add(1));
-      const missingAmount = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS).mul(
-        tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
-      );
+      const missingAmount = allTokensCostEur();
       await investAmount(investors[4], missingAmount, "EUR");
       // we should be signing NOW
       expect(await etoCommitment.state()).to.be.bignumber.eq(CommitmentState.Signing);
@@ -645,7 +661,8 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         investmentAgreementUrl,
         { from: nominee },
       );
-      expectValidClaimState(nomineeSignTx, contribution);
+      expect(await etoCommitment.state()).to.be.bignumber.eq(CommitmentState.Claim);
+      await expectValidClaimState(nomineeSignTx, contribution);
     });
 
     it("go from public to signing by reaching max cap exactly (max investment amount)", async () => {
@@ -664,9 +681,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
 
     it("go from public to signing by reaching max cap within minimum ticket (max tokens)", async () => {
       await skipTimeTo(publicStartDate.add(1));
-      const missingAmount = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS).mul(
-        tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
-      );
+      const missingAmount = allTokensCostEur();
       // MIN_TICKET is not exactly divisible by price (typically), there is a remainder which produces gap as below
       const gap = minTicketTokenGapAmount();
       // this gap makes us crossing max cap, see below test
@@ -694,12 +709,14 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
 
     it("stay in public by not reaching max cap because less than gap (max tokens)", async () => {
       await skipTimeTo(publicStartDate.add(1));
-      const missingAmount = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS).mul(
-        tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
-      );
+      const missingAmount = allTokensCostEur();
       const gap = minTicketTokenGapAmount();
       // see above test for gap explanation
-      await investAmount(investors[4], missingAmount.sub(gap).sub(1), "EUR");
+      await investAmount(
+        investors[4],
+        missingAmount.sub(gap).sub(tokenTermsDict.TOKEN_PRICE_EUR_ULPS),
+        "EUR",
+      );
       // still in public
       expect(await etoCommitment.state()).to.be.bignumber.eq(CommitmentState.Public);
     });
@@ -720,9 +737,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
 
     it("reverts on crossing max cap (max tokens)", async () => {
       await skipTimeTo(publicStartDate.add(1));
-      const missingAmount = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS).mul(
-        tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
-      );
+      const missingAmount = allTokensCostEur();
       await expect(
         investAmount(investors[4], missingAmount.add(tokenTermsDict.TOKEN_PRICE_EUR_ULPS), "EUR"),
       ).to.be.rejectedWith("NF_ETO_MAX_TOK_CAP");
@@ -757,9 +772,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       await etoTerms.addWhitelisted([investors[0]], [Q18.mul(15000000)], [Q18.mul(1)], {
         from: admin,
       });
-      const missingAmount = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS).mul(
-        tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
-      );
+      const missingAmount = allTokensCostEur();
       const tx = await investAmount(investors[0], missingAmount, "EUR");
       // we need to ignore timestamp due to ganache bug (https://github.com/trufflesuite/ganache-core/issues/111)
       expectLogStateTransition(tx, CommitmentState.Setup, CommitmentState.Whitelist, "ignore", 0);
@@ -780,7 +793,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
         etoTermsDict.WHITELIST_DISCOUNT_FRAC,
       );
-      const missingAmount = tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST.mul(dp);
+      const missingAmount = tokensCostEur(tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST, dp);
       let tx = await investAmount(investors[0], missingAmount, "EUR", dp);
       // we need to ignore timestamp due to ganache bug (https://github.com/trufflesuite/ganache-core/issues/111)
       expectLogStateTransition(tx, CommitmentState.Setup, CommitmentState.Whitelist, "ignore", 0);
@@ -806,12 +819,13 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
         etoTermsDict.WHITELIST_DISCOUNT_FRAC,
       );
-      const missingAmount = tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST.mul(dp);
-      // we should pass "dp" below but we pass full ticket price because contract always use full price to calculate situation within max cap
+      const missingAmount = tokensCostEur(tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST, dp);
       const gap = minTicketTokenGapAmount(dp);
-      // console.log(gap);
-      // this gap makes us crossing max cap, see below test
-      await investAmount(investors[0], missingAmount.sub(gap).add(dp), "EUR", dp);
+      await investAmount(investors[0], missingAmount.sub(gap), "EUR", dp);
+      // buy one more token
+      await investAmount(investors[0], dp, "EUR", dp);
+      // this will cross whitelist max cap
+      // we should pass "dp" below but we pass full ticket price because contract always use full price to calculate crossing max cap
       await expect(
         investAmount(investors[0], etoTermsDict.MIN_TICKET_EUR_ULPS, "EUR", dp),
       ).to.be.rejectedWith("NF_ETO_MAX_TOK_CAP");
@@ -826,10 +840,11 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
         etoTermsDict.WHITELIST_DISCOUNT_FRAC,
       );
-      const missingAmount = tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST.mul(dp);
+      const missingAmount = tokensCostEur(tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST, dp);
       const gap = minTicketTokenGapAmount(dp);
-      // this gap makes us crossing max cap, see below test
-      await investAmount(investors[0], missingAmount.sub(gap), "EUR", dp);
+      // console.log(`GAP ${gap} DP ${dp}`);
+      // this gap makes us crossing whitelist max
+      await investAmount(investors[0], missingAmount.sub(gap).sub(dp), "EUR", dp);
       await investAmount(investors[0], etoTermsDict.MIN_TICKET_EUR_ULPS, "EUR", dp);
       expect(await etoCommitment.state()).to.be.bignumber.eq(CommitmentState.Whitelist);
     });
@@ -843,7 +858,8 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
           from: admin,
         },
       );
-      const missingAmount = tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST.mul(
+      const missingAmount = tokensCostEur(
+        tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST,
         tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
       );
       await investAmount(investors[0], missingAmount, "EUR", tokenTermsDict.TOKEN_PRICE_EUR_ULPS);
@@ -852,7 +868,10 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
         etoTermsDict.WHITELIST_DISCOUNT_FRAC,
       );
-      const discountedMissingAmount = tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST.mul(dp);
+      const discountedMissingAmount = tokensCostEur(
+        tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST,
+        dp,
+      );
       await investAmount(
         investors[1],
         discountedMissingAmount.sub(etoTermsDict.MIN_TICKET_EUR_ULPS),
@@ -883,7 +902,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
         etoTermsDict.WHITELIST_DISCOUNT_FRAC,
       );
-      const missingAmount = tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST.mul(dp);
+      const missingAmount = tokensCostEur(tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST, dp);
       await expect(investAmount(investors[0], missingAmount.add(dp), "EUR", dp)).to.be.rejectedWith(
         "NF_ETO_MAX_TOK_CAP",
       );
@@ -912,7 +931,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       const expectedPrice = calculateMixedTranchePrice(tranche, slotTranche, slotDp, dp);
       await investAmount(investors[0], tranche, "EUR", expectedPrice);
       expect(await equityToken.balanceOf(etoCommitment.address)).to.be.bignumber.eq(
-        3873651 + 1982761,
+        getTokenPower().mul(3873651 + 1982761),
       );
     });
 
@@ -921,7 +940,8 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
         etoTermsDict.WHITELIST_DISCOUNT_FRAC,
       );
-      const tranche1 = tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST.mul(
+      const tranche1 = tokensCostEur(
+        tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST,
         tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
       );
       await etoTerms.addWhitelisted([investors[0]], [tranche1], [Q18.mul(1)], {
@@ -930,7 +950,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       // invest in fix slot that does not count into whitelist cap then cross the cap with whitelist
       await investAmount(investors[0], tranche1, "EUR", tokenTermsDict.TOKEN_PRICE_EUR_ULPS);
       expect(await etoCommitment.state()).to.be.bignumber.eq(CommitmentState.Whitelist);
-      const missingAmount = tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST.mul(dp);
+      const missingAmount = tokensCostEur(tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST, dp);
       await investAmount(
         investors[0],
         missingAmount.sub(etoTermsDict.MIN_TICKET_EUR_ULPS.mul(2)),
@@ -945,9 +965,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
 
     it("should refund if company signs too late", async () => {
       await skipTimeTo(publicStartDate.add(1));
-      const missingAmount = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS).mul(
-        tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
-      );
+      const missingAmount = allTokensCostEur();
       await investAmount(investors[4], missingAmount, "EUR");
       expect(await etoCommitment.state()).to.be.bignumber.eq(CommitmentState.Signing);
       await expectValidSigningState(investors, { expectedInvestorsCount: 1 });
@@ -962,9 +980,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
 
     it("should refund if nominee signs too late", async () => {
       await skipTimeTo(publicStartDate.add(1));
-      const missingAmount = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS).mul(
-        tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
-      );
+      const missingAmount = allTokensCostEur();
       await investAmount(investors[4], missingAmount, "EUR");
       expect(await etoCommitment.state()).to.be.bignumber.eq(CommitmentState.Signing);
       await expectValidSigningState(investors, { expectedInvestorsCount: 1 });
@@ -984,9 +1000,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
     it("refund nominee returns nominal value", async () => {
       await deployEtoWithTicket({ ovrETOTerms: { MAX_TICKET_EUR_ULPS: maxTicket.mul(10000) } });
       await skipTimeTo(publicStartDate.add(1));
-      const missingAmount = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS).mul(
-        tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
-      );
+      const missingAmount = allTokensCostEur();
       await investAmount(investors[4], missingAmount, "EUR");
       expect(await etoCommitment.state()).to.be.bignumber.eq(CommitmentState.Signing);
       const contribution = await expectValidSigningState(investors, { expectedInvestorsCount: 1 });
@@ -1003,9 +1017,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
 
     it("should allow to fundraise again on the same token", async () => {
       await skipTimeTo(publicStartDate.add(1));
-      const missingAmount = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS).mul(
-        tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
-      );
+      const missingAmount = allTokensCostEur();
       await investAmount(investors[4], missingAmount, "EUR");
       const contribution = await expectValidSigningState(investors, { expectedInvestorsCount: 1 });
       await expectExactlyMaxCap(tokenTermsDict.MAX_NUMBER_OF_TOKENS);
@@ -1019,7 +1031,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       );
       await expectValidClaimState(claimTx, contribution);
       // deploy new ETO using old token
-      const newTokenPrice = tokenTermsDict.TOKEN_PRICE_EUR_ULPS.mul("1.35");
+      const newTokenPrice = tokenTermsDict.TOKEN_PRICE_EUR_ULPS.mul("1.35").floor();
       await deployETO({
         ovrETOTerms: { MAX_TICKET_EUR_ULPS: Q18.mul(125000000) },
         ovrTokenTerms: { TOKEN_PRICE_EUR_ULPS: newTokenPrice },
@@ -1032,8 +1044,21 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       await prepareETOForPublic();
       await skipTimeTo(publicStartDate.add(1));
       const missingTokens = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS);
-      const newMissingAmount = missingTokens.mul(newTokenPrice);
+      const newMissingAmount = tokensCostEur(missingTokens, newTokenPrice);
       await investAmount(investors[1], newMissingAmount, "EUR", newTokenPrice);
+      const ticket = await etoCommitment.investorTicket(investors[1]);
+      // we must compute effective amount of tokens as ETOCommitment does that
+      // rounding problem is as follows: exact `missingTokens` cannot be bought with any nEUR amount
+      // newMissingAmount buys `effectiveTokens` < missingTokens
+      // newMissingAmount + 1 buys > missingTokens
+      const effectiveTokens = newMissingAmount.mul(getTokenPower()).divToInt(newTokenPrice);
+      const beyondEffectiveTokens = newMissingAmount
+        .add(1)
+        .mul(getTokenPower())
+        .divToInt(newTokenPrice);
+      // console.log(`${missingTokens} ${newMissingAmount} ${effectiveTokens} ${beyondEffectiveTokens}`);
+      expect(ticket[2]).to.be.bignumber.eq(effectiveTokens);
+      expect(ticket[2]).to.be.bignumber.lte(beyondEffectiveTokens);
       expect(await etoCommitment.state()).to.be.bignumber.eq(CommitmentState.Signing);
       await expectValidSigningState(investors, {
         expectedInvestorsCount: 1,
@@ -1042,8 +1067,9 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         initialNomineeBalance: oldNomineeBalance,
       });
       await expectExactlyMaxCap(tokenTermsDict.MAX_NUMBER_OF_TOKENS);
+      // do not go to claim state: 2% not yet issued
       expect(await equityToken.totalSupply()).to.be.bignumber.eq(
-        oldEquitySupply.add(missingTokens),
+        oldEquitySupply.add(effectiveTokens),
       );
     });
 
@@ -1111,9 +1137,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       await euroToken.transfer(etoCommitment.address, Q18, { from: investors[3] });
       // non erc223 transfers will deposit funds that will be lost in the contract
       await skipTimeTo(publicStartDate.add(1));
-      const missingAmount = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS).mul(
-        tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
-      );
+      const missingAmount = allTokensCostEur();
       // other investors invest, two above send regular transfers
       await investAmount(investors[0], etoTermsDict.MIN_TICKET_EUR_ULPS, "EUR");
       await investAmount(investors[1], Q18, "ETH");
@@ -1182,13 +1206,17 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
   });
 
   describe("special ETO configurations", () => {
-    it("reverts overflow on internal equity token 56 bit", async () => {
-      // totals of equity tokens are stored in 56 bits number
-      const two = new web3.BigNumber(2);
-      const one = new web3.BigNumber(1);
+    it.skip("reverts overflow on internal equity token 128 bit", async () => {
+      // totals of equity tokens are stored in 128 bits number
+      // overflowing that is practically impossible, we'll need 2^32 tickets of 2^96 tickets (which is max)
       await deployETO({
         ovrETOTerms: { MAX_TICKET_EUR_ULPS: two.pow(96), MIN_TICKET_EUR_ULPS: one },
-        ovrTokenTerms: { TOKEN_PRICE_EUR_ULPS: one, MAX_NUMBER_OF_TOKENS: two.pow(128) },
+        ovrTokenTerms: {
+          EQUITY_TOKENS_PRECISION: one.sub(one),
+          TOKEN_PRICE_EUR_ULPS: one,
+          MAX_NUMBER_OF_TOKENS: two.pow(128),
+          EQUITY_TOKENS_PER_SHARE: two.pow(16),
+        },
       });
       await prepareETOForPublic();
       await skipTimeTo(publicStartDate);
@@ -1202,7 +1230,6 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
 
     it("reverts on euro token overflow > 2**96", async () => {
       // investor ticket stores eurt equivalend in 96bit, this attempts to overflow it (without overflowing equity tokens)
-      const two = new web3.BigNumber(2);
       await deployETO({
         ovrETOTerms: { MAX_TICKET_EUR_ULPS: two.pow(128), MIN_TICKET_EUR_ULPS: two.pow(90) },
         ovrTokenTerms: { TOKEN_PRICE_EUR_ULPS: two.pow(90), MAX_NUMBER_OF_TOKENS: two.pow(128) },
@@ -1214,7 +1241,9 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       await investAmount(investors[0], two.pow(96).sub(two.pow(90).mul(2)), "EUR");
       // will generate 1 token
       await investAmount(investors[0], two.pow(90), "EUR");
-      expect(await equityToken.balanceOf(etoCommitment.address)).to.be.bignumber.eq(63);
+      expect(await equityToken.balanceOf(etoCommitment.address)).to.be.bignumber.eq(
+        getTokenPower().mul(63),
+      );
       await expect(investAmount(investors[0], two.pow(90), "EUR")).to.be.rejectedWith("");
     });
 
@@ -1258,7 +1287,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       );
       expect(await etoCommitment.timedState()).to.be.bignumber.eq(CommitmentState.Whitelist);
       await investAmount(investors[0], Q18.mul(2), "ETH", dp);
-      const missingAmount = tokenTermsDict.MIN_NUMBER_OF_TOKENS.mul(dp);
+      const missingAmount = tokensCostEur(tokenTermsDict.MIN_NUMBER_OF_TOKENS, dp);
       await investAmount(investors[1], missingAmount, "EUR");
       // skiping to public should skip directly to signing
       await skipTimeTo(publicStartDate);
@@ -1305,7 +1334,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
         etoTermsDict.WHITELIST_DISCOUNT_FRAC,
       );
-      const missingAmount = getMaxAvailableTokens(maxTokens).mul(dp);
+      const missingAmount = tokensCostEur(getMaxAvailableTokens(maxTokens), dp);
       // we immediately should go to signing, skipping public due to max cap
       const tx = await investAmount(investors[1], missingAmount, "EUR", dp);
       expectLogStateTransition(tx, CommitmentState.Setup, CommitmentState.Whitelist, "ignore", 0);
@@ -1328,7 +1357,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       await prepareETOForPublic();
       await skipTimeTo(publicStartDate);
       // minimum investment is one share, that should also shift eto to signing, because this is also max investment
-      const minimumAmount = oneShare.mul(tokenPrice);
+      const minimumAmount = tokensCostEur(oneShare, tokenPrice);
       let tx = await investAmount(investors[1], minimumAmount, "EUR", tokenPrice);
       expectLogStateTransition(tx, CommitmentState.Setup, CommitmentState.Whitelist, "ignore", 0);
       expectLogStateTransition(tx, CommitmentState.Whitelist, CommitmentState.Public, "ignore", 1);
@@ -1366,7 +1395,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       await prepareETOForPublic();
       await skipTimeTo(publicStartDate);
       // minimum investment is one share, that should also shift eto to signing, because this is also max investment
-      const minimumAmount = minTokens.mul(tokenPrice);
+      const minimumAmount = tokensCostEur(minTokens, tokenPrice);
       const tx = await investAmount(investors[1], minimumAmount, "EUR", tokenPrice);
       expectLogStateTransition(tx, CommitmentState.Setup, CommitmentState.Whitelist, "ignore", 0);
       expectLogStateTransition(tx, CommitmentState.Whitelist, CommitmentState.Public, "ignore", 1);
@@ -1374,34 +1403,115 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       await expectExactlyMaxCap(tokenTermsDict.MAX_NUMBER_OF_TOKENS);
     });
 
-    it("should use available tokens with rounding discrepancy", async () => {
-      const maxTokens = new web3.BigNumber("99843987622");
+    async function deployLargeTokensAmountOvr(tokenPrice, wholeTokens) {
+      const maxTokens = new web3.BigNumber(wholeTokens);
       const availableTokens = getMaxAvailableTokens(maxTokens);
-      const fee = await platformTerms.calculatePlatformTokenFee(availableTokens);
-      // so after reverse operation: adding available tokens to fee, we would exceed max cap in eto commitment
-      expect(availableTokens.add(fee).sub(1)).to.be.bignumber.eq(maxTokens);
-
-      const tokenPrice = Q18.div(100000);
       await deployETO({
         ovrTokenTerms: {
           MAX_NUMBER_OF_TOKENS: maxTokens,
+          MIN_NUMBER_OF_TOKENS: defEquityTokenPower,
           MAX_NUMBER_OF_TOKENS_IN_WHITELIST: new web3.BigNumber(0),
           TOKEN_PRICE_EUR_ULPS: tokenPrice,
-          EQUITY_TOKENS_PER_SHARE: new web3.BigNumber(1),
+          EQUITY_TOKENS_PER_SHARE: defEquityTokenPower,
         },
         ovrETOTerms: {
+          MIN_TICKET_EUR_ULPS: tokenPrice,
           MAX_TICKET_EUR_ULPS: maxTokens.mul(tokenPrice),
         },
       });
       await prepareETOForPublic();
       await skipTimeTo(publicStartDate);
-      // minimum investment is one share, that should also shift eto to signing, because this is also max investment
-      const maximumAmount = availableTokens.mul(tokenPrice);
-      const tx = await investAmount(investors[1], maximumAmount, "EUR", tokenPrice);
-      expectLogStateTransition(tx, CommitmentState.Setup, CommitmentState.Whitelist, "ignore", 0);
-      expectLogStateTransition(tx, CommitmentState.Whitelist, CommitmentState.Public, "ignore", 1);
-      expectLogStateTransition(tx, CommitmentState.Public, CommitmentState.Signing, "ignore", 2);
-      await expectExactlyMaxCap(maxTokens);
+
+      return availableTokens;
+    }
+
+    function getOverflowPrice() {
+      // scale price so it will generate enough tokens to overlow 2**96
+      return Q18.div(Q18.div(defEquityTokenPower).mul(10000));
+    }
+
+    it("rejects on 2**96 tokens in ticket", async () => {
+      const tokenPrice = getOverflowPrice();
+      if (tokenPrice.decimalPlaces() > 0) {
+        // eslint-disable-next-line no-console
+        console.log("...skipping test due to precise overflow tok price not existing");
+      } else {
+        const availableTokens = await deployLargeTokensAmountOvr(
+          tokenPrice,
+          Q18.mul("99843987623"),
+        );
+        const maximumAmount = tokensCostEur(availableTokens, tokenPrice);
+        await expect(investAmount(investors[1], maximumAmount, "EUR")).to.be.rejectedWith(
+          "NF_TICKET_EXCEEDS_MAX_TOK",
+        );
+      }
+    });
+
+    it("rejects on 2**96 tokens in two tickets", async () => {
+      const tokenPrice = getOverflowPrice();
+      if (tokenPrice.decimalPlaces() > 0) {
+        // eslint-disable-next-line no-console
+        console.log("...skipping test due to precise overflow tok price not existing");
+      } else {
+        await deployLargeTokensAmountOvr(tokenPrice, Q18.mul("99843987623"));
+        await investAmount(investors[1], tokensCostEur(two.pow(96).sub(1), tokenPrice), "EUR");
+        await expect(investAmount(investors[1], tokenPrice, "EUR")).to.be.rejectedWith(
+          "NF_TICKET_EXCEEDS_MAX_TOK",
+        );
+      }
+    });
+
+    it("rejects on 2**96 nEUR in ticket", async () => {
+      // investor ticket stores eurt equivalend in 96bit, this attempts to overflow it (without overflowing equity tokens)
+      const tokenPrice = Q18;
+      const availableTokens = await deployLargeTokensAmountOvr(tokenPrice, Q18.mul("99843987623"));
+      const maximumAmount = tokensCostEur(availableTokens, tokenPrice);
+      await expect(investAmount(investors[1], maximumAmount, "EUR")).to.be.rejectedWith(
+        "NF_TICKET_EXCEEDS_MAX_EUR",
+      );
+    });
+
+    it("rejects on 2**96 nEUR in two tickets", async () => {
+      const tokenPrice = Q18;
+      await deployLargeTokensAmountOvr(tokenPrice, Q18.mul("99843987623"));
+      await investAmount(investors[1], two.pow("96").sub(tokenPrice), "EUR");
+      await expect(investAmount(investors[1], tokenPrice, "EUR")).to.be.rejectedWith(
+        "NF_TICKET_EXCEEDS_MAX_EUR",
+      );
+    });
+
+    it("should use available tokens with rounding discrepancy", async () => {
+      if (defEquityTokenPrecision.eq(0)) {
+        // this is magic number of tokens that generate rounding discrepancy, disregard precision
+        const maxTokens = new web3.BigNumber("99843987622");
+        const availableTokens = getMaxAvailableTokens(maxTokens);
+        const fee = await platformTerms.calculatePlatformTokenFee(availableTokens);
+        // so after reverse operation: adding available tokens to fee, we would exceed max cap in eto commitment
+        expect(availableTokens.add(fee).sub(1)).to.be.bignumber.eq(maxTokens);
+
+        const tokenPrice = getOverflowPrice()
+          .mul(10000)
+          .floor();
+        await deployLargeTokensAmountOvr(tokenPrice, maxTokens);
+        // minimum investment is one share, that should also shift eto to signing, because this is also max investment
+        const maximumAmount = tokensCostEur(availableTokens, tokenPrice);
+        // availableTokens may not be reached by any investment amount
+        // see comments should allow to fundraise again on the same token
+        const tx = await investAmount(investors[1], maximumAmount, "EUR", tokenPrice);
+        expectLogStateTransition(tx, CommitmentState.Setup, CommitmentState.Whitelist, "ignore", 0);
+        expectLogStateTransition(
+          tx,
+          CommitmentState.Whitelist,
+          CommitmentState.Public,
+          "ignore",
+          1,
+        );
+        expectLogStateTransition(tx, CommitmentState.Public, CommitmentState.Signing, "ignore", 2);
+        await expectExactlyMaxCap(defEquityTokenPower.mul(maxTokens));
+      } else {
+        // eslint-disable-next-line no-console
+        console.log("...tests only for precision 0 - magic number of tokens used");
+      }
     });
 
     it("should enable transfer on equity token on success", async () => {
@@ -1414,9 +1524,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       });
       await prepareETOForPublic();
       await skipTimeTo(publicStartDate);
-      const missingAmount = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS).mul(
-        tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
-      );
+      const missingAmount = allTokensCostEur();
       await investAmount(investors[1], missingAmount, "EUR");
       await moveETOToClaim(1, new web3.BigNumber(0));
       await claimInvestor(investors[1]);
@@ -1430,9 +1538,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       });
       await prepareETOForPublic();
       await skipTimeTo(publicStartDate);
-      const missingAmount = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS).mul(
-        tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
-      );
+      const missingAmount = allTokensCostEur();
       await investAmount(investors[1], missingAmount, "EUR");
       await moveETOToClaim(1, new web3.BigNumber(0));
       await claimInvestor(investors[1]);
@@ -1451,9 +1557,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       await deployETO({ ovrETOTerms: { MAX_TICKET_EUR_ULPS: Q18.mul(15000000) } });
       await prepareETOForPublic();
       await skipTimeTo(publicStartDate);
-      const missingAmount = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS).mul(
-        tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
-      );
+      const missingAmount = allTokensCostEur();
       await investAmount(investors[1], missingAmount, "EUR");
       await moveETOToClaim(1, new web3.BigNumber(0));
       await claimInvestor(investors[1]);
@@ -1463,7 +1567,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       await etoCommitment.payout();
       // check if disbursal happened
       expect(await euroToken.balanceOf(simpleAccountDisbursal)).to.be.bignumber.eq(
-        missingAmount.mul(0.03).round(0, 4),
+        missingAmount.mul("0.03").round(0, 4),
       );
     });
 
@@ -1471,7 +1575,8 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       await deployETO({ ovrETOTerms: { MAX_TICKET_EUR_ULPS: Q18.mul(15000000) } });
       await prepareETOForPublic();
       await skipTimeTo(publicStartDate);
-      const missingAmount = tokenTermsDict.MIN_NUMBER_OF_TOKENS.mul(
+      const missingAmount = tokensCostEur(
+        tokenTermsDict.MIN_NUMBER_OF_TOKENS,
         tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
       );
       const ethAmount = Q18.mul(232).add(1);
@@ -1502,7 +1607,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
     });
 
     it("should invest in ETO with public discount and have full valuation", async () => {
-      const publicDiscount = Q18.mul(0.2);
+      const publicDiscount = Q18.mul("0.2");
       await deployETO({
         ovrETOTerms: {
           MAX_TICKET_EUR_ULPS: Q18.mul(15000000),
@@ -1517,7 +1622,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       await etoTerms.addWhitelisted(
         [investors[0], investors[1], investors[2]],
         [0, 0, Q18.mul(10000)],
-        [Q18, Q18, Q18.mul(0.3)],
+        [Q18, Q18, Q18.mul("0.3")],
         {
           from: admin,
         },
@@ -1539,9 +1644,10 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       await investAmount(investors[3], Q18.mul(121.12), "ETH", publicPrice);
 
       const tokensSold = (await etoCommitment.totalInvestment())[1];
-      const missingAmount = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS)
-        .sub(tokensSold)
-        .mul(publicPrice);
+      const missingTokens = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS).sub(
+        tokensSold,
+      );
+      const missingAmount = tokensCostEur(missingTokens, publicPrice);
       await investAmount(investors[1], missingAmount, "EUR", publicPrice);
       const contribution = await moveETOToClaim(4, new web3.BigNumber(0));
       await expectExactlyMaxCap(tokenTermsDict.MAX_NUMBER_OF_TOKENS);
@@ -1570,7 +1676,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
     it("should allow simple price and valuation formulas for simple shareholding struct", async () => {
       // we can use various simplified formula for ETOs where all shares are identical and have 1 EUR value
       // so number of shares = share capital
-      const tokensPerShare = new web3.BigNumber("10000");
+      const tokensPerShare = new web3.BigNumber("10000").mul(defEquityTokenPower);
       await deployETO({
         ovrTokenTerms: {
           SHARE_NOMINAL_VALUE_ULPS: Q18,
@@ -1622,13 +1728,17 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       expect(shareholderInfo[1]).to.be.bignumber.eq(totalSharesCapitalPost.mul("200"));
     });
 
-    async function deployLargeSharePriceOvr() {
-      const tokensPerShare = new web3.BigNumber("10000");
+    async function deployLargeSharePriceOvr(precision) {
+      const ovrTokenTerms = {
+        EQUITY_TOKENS_PRECISION: precision || defEquityTokenPrecision,
+      };
+      const tokenPower = getTokenPower(ovrTokenTerms);
+      const tokensPerShare = new web3.BigNumber("10000").mul(tokenPower);
       const sharePrice = Q18.mul("161870.503597122");
-      const tokenPrice = sharePrice.div(tokensPerShare).floor();
+      const tokenPrice = sharePrice.mul(tokenPower).divToInt(tokensPerShare);
       const shareNominalValue = Q18.mul(100);
       await deployETO({
-        ovrTokenTerms: {
+        ovrTokenTerms: Object.assign(ovrTokenTerms, {
           SHARE_NOMINAL_VALUE_ULPS: shareNominalValue,
           SHARE_NOMINAL_VALUE_EUR_ULPS: Q18.mul("13.5"),
           EQUITY_TOKENS_PER_SHARE: tokensPerShare,
@@ -1636,7 +1746,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
           MIN_NUMBER_OF_TOKENS: tokensPerShare.mul(6),
           MAX_NUMBER_OF_TOKENS: tokensPerShare.mul(30),
           MAX_NUMBER_OF_TOKENS_IN_WHITELIST: tokensPerShare.mul(30),
-        },
+        }),
         ovrETOTerms: {
           MAX_TICKET_EUR_ULPS: Q18.mul("5000000"),
           MIN_TICKET_EUR_ULPS: Q18.mul("20"),
@@ -1649,7 +1759,8 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
 
     it("should lose significant amount when buying non round number of tokens", async () => {
       // we buy for 160 EUR which is almost 10 tokens, but almost makes a big difference
-      await deployLargeSharePriceOvr();
+      // we use low equity token precision to inflate rounding
+      await deployLargeSharePriceOvr(new web3.BigNumber("0"));
       // make full cap in one go
       await prepareETOForPublic();
       await skipTimeTo(publicStartDate);
@@ -1717,7 +1828,8 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       await deployETO({ ovrETOTerms: { MAX_TICKET_EUR_ULPS: Q18.mul(15000000) } });
       await prepareETOForPublic();
       await skipTimeTo(publicStartDate);
-      const missingAmount = tokenTermsDict.MIN_NUMBER_OF_TOKENS.mul(
+      const missingAmount = tokensCostEur(
+        tokenTermsDict.MIN_NUMBER_OF_TOKENS,
         tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
       );
       await investICBMAmount(investors[0], Q18.mul(762.192).add(1), "EUR");
@@ -1951,11 +2063,11 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       await deployETO({ ovrETOTerms: { MAX_TICKET_EUR_ULPS: Q18.mul(15000000) } });
       await prepareETOForPublic();
       await skipTimeTo(publicStartDate);
-      await investICBMAmount(investors[0], Q18.mul(762.192).add(1), "EUR");
-      await investICBMAmount(investors[1], Q18.mul(12.761).add(1), "ETH");
+      await investICBMAmount(investors[0], Q18.mul("762.192").add(1), "EUR");
+      await investICBMAmount(investors[1], Q18.mul("12.761").add(1), "ETH");
       const icbmEurEquiv = (await etoCommitment.totalInvestment())[0];
-      await investAmount(investors[0], Q18.mul(762.192).add(1), "ETH");
-      await investAmount(investors[1], Q18.mul(258272.121), "EUR");
+      await investAmount(investors[0], Q18.mul("762.192").add(1), "ETH");
+      await investAmount(investors[1], Q18.mul("258272.121"), "EUR");
       const signingStartOf = publicStartDate.add(durTable[CommitmentState.Public]);
       await skipTimeTo(signingStartOf.add(1));
       const refundTx = await etoCommitment.handleStateTransitions();
@@ -2077,7 +2189,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       });
       // go to public
       await skipTimeTo(publicStartDate.add(1));
-      const amount = Q18.mul(87219.291).add(1);
+      const amount = Q18.mul("87219.291").add(1);
       const contrib = await etoCommitment.calculateContribution(investors[0], false, amount);
       // is whitelisted
       expect(contrib[0]).to.be.true;
@@ -2087,26 +2199,24 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       // returns public max ticket
       expect(contrib[3]).to.be.bignumber.eq(etoTermsDict.MAX_TICKET_EUR_ULPS);
       // always round down in equity token calc
-      const equityAmount = amount.div(tokenTermsDict.TOKEN_PRICE_EUR_ULPS).floor();
+      const equityAmount = amount
+        .mul(getTokenPower())
+        .divToInt(tokenTermsDict.TOKEN_PRICE_EUR_ULPS);
       expect(contrib[4]).to.be.bignumber.eq(equityAmount);
       const neuAmount = investorShare(await neumark.incremental(amount));
       expect(contrib[5]).to.be.bignumber.eq(neuAmount);
       expect(contrib[6]).to.be.false;
-      // todo: now just returns 'amount' write set of tests when there's actual implementation
-      expect(contrib[7]).to.be.bignumber.eq(amount);
       // invest
       await investAmount(investors[0], amount, "EUR");
       // next contrib
       const contrib2 = await etoCommitment.calculateContribution(investors[0], false, amount);
       expect(contrib2[4]).to.be.bignumber.eq(contrib[4]);
-      expect(contrib[7]).to.be.bignumber.eq(amount);
       // NEU reward drops
       expect(contrib2[5]).to.be.bignumber.lt(contrib[5]);
       // icbm contrib
       const contrib3 = await etoCommitment.calculateContribution(investors[0], true, amount);
       expect(contrib3[4]).to.be.bignumber.eq(contrib[4]);
       expect(contrib3[5]).to.be.bignumber.eq(0);
-      expect(contrib[7]).to.be.bignumber.eq(amount);
     });
 
     it("should calculate contribution in whitelist with discounts", async () => {
@@ -2117,7 +2227,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
         etoTermsDict.WHITELIST_DISCOUNT_FRAC,
       );
-      const amount = Q18.mul(87219.291);
+      const amount = Q18.mul("87219.291");
       const contrib = await etoCommitment.calculateContribution(investors[0], false, amount);
       expect(contrib[0]).to.be.true;
       expect(contrib[1]).to.be.true;
@@ -2125,7 +2235,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       // returns public max ticket
       expect(contrib[3]).to.be.bignumber.eq(etoTermsDict.MAX_TICKET_EUR_ULPS);
       // always round down in equity token calc
-      const equityAmount = amount.div(dp).floor();
+      const equityAmount = amount.mul(getTokenPower()).divToInt(dp);
       expect(contrib[4]).to.be.bignumber.eq(equityAmount);
       const neuAmount = investorShare(await neumark.incremental(amount));
       expect(contrib[5]).to.be.bignumber.eq(neuAmount);
@@ -2140,7 +2250,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
     });
 
     it("calculate contribution in whitelist when fixed slots", async () => {
-      const discount = Q18.mul(0.3);
+      const discount = Q18.mul("0.428337298");
       const fixedAmount = Q18.mul(20000);
       const overMaxTicket = etoTermsDict.MAX_TICKET_EUR_ULPS.add(10000);
       await etoTerms.addWhitelisted(
@@ -2151,6 +2261,8 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
           from: admin,
         },
       );
+
+      const tokenPower = getTokenPower();
       const slotPrice = discountedPrice(tokenTermsDict.TOKEN_PRICE_EUR_ULPS, discount);
       const contrib = await etoCommitment.calculateContribution(investors[0], false, fixedAmount);
       expect(contrib[0]).to.be.true;
@@ -2159,7 +2271,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       // returns public max ticket
       expect(contrib[3]).to.be.bignumber.eq(etoTermsDict.MAX_TICKET_EUR_ULPS);
       // always round down in equity token calc
-      const equityAmount = fixedAmount.div(slotPrice).floor();
+      const equityAmount = fixedAmount.mul(tokenPower).divToInt(slotPrice);
       expect(contrib[4]).to.be.bignumber.eq(equityAmount);
       const neuAmount = investorShare(await neumark.incremental(fixedAmount));
       expect(contrib[5]).to.be.bignumber.eq(neuAmount);
@@ -2178,10 +2290,12 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         etoTermsDict.WHITELIST_DISCOUNT_FRAC,
       );
       const mixedPrice = calculateMixedTranchePrice(fixedAmount.mul(2), fixedAmount, slotPrice, dp);
+      // use HALF_UP as this is approximate high precision price
       const mixedEquityAmount = fixedAmount
         .mul(2)
+        .mul(tokenPower)
         .div(mixedPrice)
-        .floor();
+        .round(0, 4);
       expect(contrib3[4]).to.be.bignumber.eq(mixedEquityAmount);
     });
 
@@ -2193,7 +2307,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
         etoTermsDict.WHITELIST_DISCOUNT_FRAC,
       );
-      const wlMaxCap = tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST.mul(dp);
+      const wlMaxCap = tokensCostEur(tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST, dp);
       const wlContrib = await etoCommitment.calculateContribution(investors[0], false, wlMaxCap);
       expect(wlContrib[6]).to.be.false;
       const wlContrib2 = await etoCommitment.calculateContribution(
@@ -2203,11 +2317,12 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       );
       expect(wlContrib2[6]).to.be.true;
       const discountedTokens = tokenTermsDict.EQUITY_TOKENS_PER_SHARE;
-      await investAmount(investors[0], dp.mul(discountedTokens), "EUR");
+      await investAmount(investors[0], tokensCostEur(discountedTokens, dp), "EUR");
       await skipTimeTo(publicStartDate.add(1));
-      const maxCap = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS)
-        .sub(discountedTokens)
-        .mul(tokenTermsDict.TOKEN_PRICE_EUR_ULPS);
+      const maxTokens = getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS).sub(
+        discountedTokens,
+      );
+      const maxCap = tokensCostEur(maxTokens, tokenTermsDict.TOKEN_PRICE_EUR_ULPS);
       const contrib = await etoCommitment.calculateContribution(investors[0], false, maxCap);
       expect(contrib[6]).to.be.false;
       const contrib2 = await etoCommitment.calculateContribution(
@@ -2224,7 +2339,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       const feeTokens = tokenTermsDict.MAX_NUMBER_OF_TOKENS.sub(maxAvailableTokens);
       await deployETO({
         ovrTokenTerms: {
-          MAX_NUMBER_OF_TOKENS_IN_WHITELIST: maxAvailableTokens.add(feeTokens.div(2).floor()),
+          MAX_NUMBER_OF_TOKENS_IN_WHITELIST: maxAvailableTokens.add(feeTokens.divToInt(2)),
         },
       });
       await prepareETOForPublic();
@@ -2235,7 +2350,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
         etoTermsDict.WHITELIST_DISCOUNT_FRAC,
       );
-      const wlMaxCap = maxAvailableTokens.mul(dp);
+      const wlMaxCap = tokensCostEur(maxAvailableTokens, dp);
       const wlContrib = await etoCommitment.calculateContribution(investors[0], false, wlMaxCap);
       expect(wlContrib[6]).to.be.false;
       const wlContrib2 = await etoCommitment.calculateContribution(
@@ -2260,7 +2375,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
         etoTermsDict.WHITELIST_DISCOUNT_FRAC,
       );
-      const wlMaxCap = tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST.mul(dp);
+      const wlMaxCap = tokensCostEur(tokenTermsDict.MAX_NUMBER_OF_TOKENS_IN_WHITELIST, dp);
       // investor 0 must be able to invest over whitelist max cap because he has slot > this cap
       const wlContrib2 = await etoCommitment.calculateContribution(
         investors[0],
@@ -2427,9 +2542,9 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         );
         // invest some
         await investAmount(investors[0], Q18.add(1), "ETH", dp);
-        await investAmount(investors[0], Q18.mul(1.1289791).sub(1), "ETH", dp);
-        await investAmount(investors[1], Q18.mul(0.9528763), "ETH", dp);
-        await investAmount(investors[0], Q18.mul(30876.18912), "EUR", dp);
+        await investAmount(investors[0], Q18.mul("1.1289791").sub(1), "ETH", dp);
+        await investAmount(investors[1], Q18.mul("0.9528763"), "ETH", dp);
+        await investAmount(investors[0], Q18.mul("30876.18912"), "EUR", dp);
         publicStartDate = startDate.add(durTermsDict.WHITELIST_DURATION);
         // console.log(new Date(publicStartDate * 1000));
         await skipTimeTo(publicStartDate.add(1));
@@ -2452,9 +2567,9 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         // we have constant price in this use case - no discounts
         const tokenprice = tokenTermsDict.TOKEN_PRICE_EUR_ULPS;
         // invest so we have min cap
-        await investAmount(investors[1], Q18.mul(130876.61721), "EUR", tokenprice);
+        await investAmount(investors[1], Q18.mul("130876.61721"), "EUR", tokenprice);
         // out of whitelist
-        await investAmount(investors[2], Q18.mul(1500.1721), "ETH", tokenprice);
+        await investAmount(investors[2], Q18.mul("1500.1721"), "ETH", tokenprice);
         await investAmount(
           investors[3],
           etoTermsDict.MAX_TICKET_EUR_ULPS.div(2),
@@ -2468,12 +2583,12 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         // we must cross MIN CAP
         if (tokenTermsDict.MIN_NUMBER_OF_TOKENS.gt(totalInvestment[1])) {
           const missingTokens = tokenTermsDict.MIN_NUMBER_OF_TOKENS.sub(totalInvestment[1]);
-          let missingAmount = missingTokens.mul(tokenTermsDict.TOKEN_PRICE_EUR_ULPS);
+          let missingAmount = tokensCostEur(missingTokens, tokenTermsDict.TOKEN_PRICE_EUR_ULPS);
           if (missingAmount.lt(etoTermsDict.MIN_TICKET_EUR_ULPS)) {
             missingAmount = etoTermsDict.MIN_TICKET_EUR_ULPS;
           }
           // console.log(`min cap investment: ${missingTokens} ${missingAmount} EUR`);
-          await investAmount(investors[4], missingAmount, "EUR", tokenprice);
+          await investAmount(investors[4], missingAmount.add(1), "EUR", tokenprice);
         }
         // go to signing
         await skipTimeTo(signingStartOf.add(1));
@@ -2574,7 +2689,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         await expectValidPayoutState(tx, contribution);
         await expectValidPayoutStateFullClaim(tx);
       });
-      it("mixed currency with fixed slots and successful", async () => {});
+      it("mixed currency with fixed slots and successful");
       it("mixed currency and refunded");
       it("mixed currency with fixed slots and refunded");
       it("ether only and successful");
@@ -2599,17 +2714,17 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         );
         // invest from ICBM contract
         await investICBMAmount(investors[0], Q18.add(1), "ETH", dp);
-        await investICBMAmount(investors[0], Q18.mul(7.87261621).sub(1), "ETH", dp);
-        await investICBMAmount(investors[1], Q18.mul(34.098171), "ETH", dp);
-        await investICBMAmount(investors[0], Q18.mul(73692.76198871).add(1), "EUR", dp);
+        await investICBMAmount(investors[0], Q18.mul("7.87261621").sub(1), "ETH", dp);
+        await investICBMAmount(investors[1], Q18.mul("34.098171"), "ETH", dp);
+        await investICBMAmount(investors[0], Q18.mul("73692.76198871").add(1), "EUR", dp);
         await skipTimeTo(publicStartDate.add(1));
         await etoCommitment.handleStateTransitions();
         // we have constant price in this use case - no discounts
         const tokenprice = tokenTermsDict.TOKEN_PRICE_EUR_ULPS;
         // invest so we have min cap
-        await investICBMAmount(investors[1], Q18.mul(611527.8172891), "EUR", tokenprice);
+        await investICBMAmount(investors[1], Q18.mul("611527.8172891"), "EUR", tokenprice);
         // out of whitelist
-        await investICBMAmount(investors[2], Q18.mul(417.817278172), "ETH", tokenprice);
+        await investICBMAmount(investors[2], Q18.mul("417.817278172"), "ETH", tokenprice);
         await investICBMAmount(
           investors[3],
           etoTermsDict.MAX_TICKET_EUR_ULPS.div(2),
@@ -2623,12 +2738,12 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         // we must cross MIN CAP
         if (tokenTermsDict.MIN_NUMBER_OF_TOKENS.gt(totalInvestment[1])) {
           const missingTokens = tokenTermsDict.MIN_NUMBER_OF_TOKENS.sub(totalInvestment[1]);
-          let missingAmount = missingTokens.mul(tokenTermsDict.TOKEN_PRICE_EUR_ULPS);
+          let missingAmount = tokensCostEur(missingTokens, tokenTermsDict.TOKEN_PRICE_EUR_ULPS);
           if (missingAmount.lt(etoTermsDict.MIN_TICKET_EUR_ULPS)) {
             missingAmount = etoTermsDict.MIN_TICKET_EUR_ULPS;
           }
           // console.log(`min cap investment: ${missingTokens} ${missingAmount} EUR`);
-          await investICBMAmount(investors[4], missingAmount, "EUR", tokenprice);
+          await investICBMAmount(investors[4], missingAmount.add(1), "EUR", tokenprice);
         }
         const icbmEurEquiv = (await etoCommitment.totalInvestment())[0];
         // go to signing
@@ -2744,16 +2859,16 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         const wasEthUsed = (await etherToken.balanceOf(etoCommitment.address)).gt(0);
         if (tokenTermsDict.MIN_NUMBER_OF_TOKENS.gt(totalInvestment[1])) {
           const missingTokens = tokenTermsDict.MIN_NUMBER_OF_TOKENS.sub(totalInvestment[1]);
-          let missingAmount = missingTokens.mul(tokenTermsDict.TOKEN_PRICE_EUR_ULPS);
+          let missingAmount = tokensCostEur(missingTokens, tokenTermsDict.TOKEN_PRICE_EUR_ULPS);
           if (missingAmount.lt(etoTermsDict.MIN_TICKET_EUR_ULPS)) {
             missingAmount = etoTermsDict.MIN_TICKET_EUR_ULPS;
           }
           // console.log(`min cap investment: ${missingTokens} ${missingAmount} EUR`);
           // check if finalize with ETH or EUR
           if (wasEurUsed) {
-            await investAmount(regularInvestors[0], missingAmount, "EUR");
+            await investAmount(regularInvestors[0], missingAmount.add(1), "EUR");
           } else {
-            await investAmount(regularInvestors[0], eurToEth(missingAmount), "ETH");
+            await investAmount(regularInvestors[0], eurToEth(missingAmount.add(1)), "ETH");
           }
         }
         // go to signing
@@ -3023,9 +3138,11 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       it("ether only and successful", async () => {
         async function investment(regularInvestors, icbmInvestors) {
           // allow to cross max cap from whitelist (fixed-slot)
+          const inv0FixedSlot = Q18.mul(10000);
+          const ethPrice = "100";
           await etoTerms.addWhitelisted(
             [icbmInvestors[0], icbmInvestors[1], regularInvestors[0]],
-            [Q18.mul(10000), Q18.mul(0), Q18.mul(16000)],
+            [inv0FixedSlot, Q18.mul(0), Q18.mul(16000)],
             [Q18.mul("0.4"), Q18.mul(1), Q18.mul("0.3")],
             {
               from: admin,
@@ -3039,37 +3156,55 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
             tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
             Q18.sub(Q18.mul(0.4)),
           );
+          // set round exchange rate to minimize rounding errors
+          // set some round ETH price to minimize rounding errors in the contract
+          await gasExchange.setExchangeRate(
+            etherToken.address,
+            euroToken.address,
+            Q18.mul(ethPrice),
+            {
+              from: admin,
+            },
+          );
           // first icbm so we can measure euro
           await investICBMAmount(icbmInvestors[0], Q18.mul(10), "ETH", icbmInvestor0Dp);
           await investICBMAmount(icbmInvestors[1], Q18.mul(172).add(1), "ETH", dp);
           const icbmEurEquiv = (await etoCommitment.totalInvestment())[0];
-          // 10000 from slot, 2000 from wl, then icbm
-          const inv02Balance = (await etoCommitment.investorTicket(icbmInvestors[0]))[0];
+          // invest remaining slot
+          const inv0Balance = (await etoCommitment.investorTicket(icbmInvestors[0]))[0];
           await investAmount(
             icbmInvestors[0],
-            eurToEth(Q18.mul(10000).sub(inv02Balance)),
+            eurToEth(inv0FixedSlot.sub(inv0Balance), ethPrice),
             "ETH",
             icbmInvestor0Dp,
           );
-          await investAmount(icbmInvestors[0], eurToEth(Q18.mul(2000)), "ETH", dp);
+          // fixed slot must be exactly filled, otherwise next test will not pass
+          expect((await etoCommitment.investorTicket(icbmInvestors[0]))[0]).to.be.bignumber.eq(
+            inv0FixedSlot,
+          );
+          // 10000 from slot, 2000 from wl, then icbm
+          await investAmount(icbmInvestors[0], eurToEth(Q18.mul(2000), ethPrice), "ETH", dp);
           // whitelist and icbm
           const regularInvestor0Dp = discountedPrice(
             tokenTermsDict.TOKEN_PRICE_EUR_ULPS,
             Q18.sub(Q18.mul("0.3")),
           );
+          // we used Q18.mul("78197.121").add(1) but that caused rounding error due to
+          // eth 1/100 eur rate rounding conversion that was losing that 1 wei
+          // this two tranche price must exactly overlap with smart contract to a single wei
           const expectedPrice = calculateMixedTranchePrice(
-            Q18.mul("78197.121").add(1),
+            Q18.mul("78197.121"),
             Q18.mul(16000),
             regularInvestor0Dp,
             dp,
           );
           await investAmount(
             regularInvestors[0],
-            eurToEth(Q18.mul("78197.121").add(1)),
+            eurToEth(Q18.mul("78197.121"), ethPrice),
             "ETH",
             expectedPrice,
           );
-          //
+          // this will reset eth price to default
           await skipTimeTo(publicStartDate.add(1));
           // same amounts in public
           await investAmount(
@@ -3174,9 +3309,9 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
     });
   });
 
-  function eurToEth(amount) {
+  function eurToEth(amount, price) {
     // compute inverse rate
-    const invRateQ18 = Q18.div(defEthPrice).round(0, 4);
+    const invRateQ18 = Q18.div(price || defEthPrice).round(0, 4);
     // use inv rate to convert eur to eth, when feed to smart contract which uses
     // eth to eur conversion and normal rate, rounding should match
     return divRound(amount.mul(invRateQ18), Q18);
@@ -3571,7 +3706,11 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       expectedNeu = expectedNeu.sub(1);
     }
     // use overloaded erc223 to transfer to contract with callback
-    // console.log(`investor ${investor} INVESTING`);
+    // console.log(
+    //   `investor ${investor} INVESTING ${amount.toString("10")} ${currency} ${eurEquiv.toString(
+    //     "10",
+    //   )}`,
+    // );
     const tx = await token.transfer["address,uint256,bytes"](etoCommitment.address, amount, "", {
       from: investor,
     });
@@ -3584,27 +3723,33 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
     expect(ticket[1]).to.be.bignumber.eq(expectedNeu.add(oldTicket[1]));
     // check only if expected token price was given
     let expectedEquity;
+    const tokenPower = getTokenPower();
     if (expectedPrice) {
-      // we always round down when computing equity tokens
-      expectedEquity = eurEquiv.div(expectedPrice).floor();
+      // for integer prices use smart contract rounding
+      if (expectedPrice.decimalPlaces() === 0) {
+        // we always round down when computing equity tokens
+        expectedEquity = eurEquiv.mul(tokenPower).divToInt(expectedPrice);
+      } else {
+        // this is effective price that is used to approximate smart contract rounding
+        // give as much precision as possible
+        expectedEquity = divRound(eurEquiv.mul(tokenPower), expectedPrice);
+      }
       // compare expected price only on first tranche of investment - later those depend on previous
       // tranches
       if (oldTicket[0].eq(0)) {
         // the actual price will be slightly higher (or equal) than the expected price
         // due to tokens being indivisible - and we always floor the number of tokens bought
         // example: token cost is 1 eur, you pay 1.9 eur, you get 1 token, your price is 1.9 eur
-        expect(ticket[4]).to.be.bignumber.eq(eurEquiv.div(expectedEquity).floor());
+        // expect(ticket[4]).to.be.bignumber.eq(divRound(eurEquiv.mul(tokenPower), expectedEquity));
       }
     } else {
       expectedEquity = ticket[2].sub(oldTicket[2]);
     }
     expect(ticket[2].sub(oldTicket[2])).to.be.bignumber.eq(expectedEquity);
-    // computes tokens per share decimal count
-    const QT = Q18.div(
-      new web3.BigNumber(10).pow(Math.log10(tokenTermsDict.EQUITY_TOKENS_PER_SHARE.toNumber())),
+    // fraction of shares (would be cool to compute just difference but we accumulate roundings!)
+    expect(ticket[3]).to.be.bignumber.eq(
+      divRound(expectedEquity.add(oldTicket[2]).mul(Q18), tokenTermsDict.EQUITY_TOKENS_PER_SHARE),
     );
-    // this assumes equity token precision is 0
-    expect(ticket[3].sub(oldTicket[3])).to.be.bignumber.eq(expectedEquity.mul(QT));
     if (currency === "ETH") {
       expect(ticket[6]).to.be.bignumber.eq(amount.add(oldTicket[6]));
     }
@@ -3626,6 +3771,21 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       expectedNeu,
     );
     return tx;
+  }
+
+  function getTokenPower(terms) {
+    return decimalBase.pow((terms || tokenTermsDict).EQUITY_TOKENS_PRECISION);
+  }
+
+  function tokensCostEur(tokens, price) {
+    return tokens.mul(price).divToInt(getTokenPower());
+  }
+
+  function allTokensCostEur(price) {
+    const p = price || tokenTermsDict.TOKEN_PRICE_EUR_ULPS;
+    return getMaxAvailableTokens(tokenTermsDict.MAX_NUMBER_OF_TOKENS)
+      .mul(p)
+      .divToInt(getTokenPower());
   }
 
   async function investICBMAmount(investor, amount, currency, expectedPrice) {
@@ -3652,6 +3812,11 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
     // icbm investor already got NEU
     const expectedNeu = new web3.BigNumber(0);
     // investor sends money via wallet
+    // console.log(
+    //   `ICBM investor ${investor} INVESTING ${amount.toString("10")} ${currency} ${eurEquiv.toString(
+    //     "10",
+    //   )}`,
+    // );
     const tx = await wallet.transfer(etoCommitment.address, amount, "", {
       from: investor,
     });
@@ -3664,27 +3829,33 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
     expect(ticket[1]).to.be.bignumber.eq(expectedNeu.add(oldTicket[1]));
     // check only if expected token price was given
     let expectedEquity;
+    const tokenPower = getTokenPower();
     if (expectedPrice) {
-      // we always round down when computing equity tokens
-      expectedEquity = eurEquiv.div(expectedPrice).floor();
+      // for integer prices use smart contract rounding
+      if (expectedPrice.decimalPlaces() === 0) {
+        // we always round down when computing equity tokens
+        expectedEquity = eurEquiv.mul(tokenPower).divToInt(expectedPrice);
+      } else {
+        // this is effective price that is used to approximate smart contract rounding
+        // give as much precision as possible
+        expectedEquity = divRound(eurEquiv.mul(tokenPower), expectedPrice);
+      }
       // compare expected price only on first tranche of investment - later those depend on previous
       // tranches
       if (oldTicket[0].eq(0)) {
         // the actual price will be slightly higher (or equal) than the expected price
         // due to tokens being indivisible - and we always floor the number of tokens bought
         // example: token cost is 1 eur, you pay 1.9 eur, you get 1 token, your price is 1.9 eur
-        expect(ticket[4]).to.be.bignumber.eq(eurEquiv.div(expectedEquity).floor());
+        expect(ticket[4]).to.be.bignumber.eq(divRound(eurEquiv.mul(tokenPower), expectedEquity));
       }
     } else {
       expectedEquity = ticket[2].sub(oldTicket[2]);
     }
     expect(ticket[2].sub(oldTicket[2])).to.be.bignumber.eq(expectedEquity);
-    // computes tokens per share decimal count
-    const QT = Q18.div(
-      new web3.BigNumber(10).pow(Math.log10(tokenTermsDict.EQUITY_TOKENS_PER_SHARE.toNumber())),
+    // fraction of shares (would be cool to compute just difference but we accumulate roundings!)
+    expect(ticket[3]).to.be.bignumber.eq(
+      divRound(expectedEquity.add(oldTicket[2]).mul(Q18), tokenTermsDict.EQUITY_TOKENS_PER_SHARE),
     );
-    // this assumes equity token precision is 0
-    expect(ticket[3].sub(oldTicket[3])).to.be.bignumber.eq(expectedEquity.mul(QT));
     if (currency === "ETH") {
       expect(ticket[6]).to.be.bignumber.eq(amount.add(oldTicket[6]));
     }
@@ -3862,7 +4033,7 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
         increasedShareCapitalUlps
           .mul(tokenTermsDict.TOKEN_PRICE_EUR_ULPS)
           .mul(tokenTermsDict.EQUITY_TOKENS_PER_SHARE),
-        tokenTermsDict.SHARE_NOMINAL_VALUE_ULPS,
+        tokenTermsDict.SHARE_NOMINAL_VALUE_ULPS.mul(getTokenPower()),
       ),
     );
     expect(generalInformation[2]).to.eq(shareholderRights.address);
@@ -4085,31 +4256,62 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
     return divRound(price.mul(Q18.sub(discount)), Q18);
   }
 
-  function calculateMixedTranchePrice(totalAmount, tranche1Amount, tranche1Price, tranche2Price) {
+  function calculateMixedTranchePriceLinear(
+    totalAmount,
+    tranche1Amount,
+    tranche1Price,
+    tranche2Price,
+  ) {
     const tranche2Amount = totalAmount.sub(tranche1Amount);
     // to approximate real mixed price we must also take into account that tokens are quantized so
     // we lose some funds on the edge between two tranches as in each tranche tokens are acquired
     // independently and some funds are lost due to rounding
+    const tokenPower = getTokenPower();
     const tranche1QuantizedAmount = tranche1Amount
-      .div(tranche1Price)
-      .floor()
-      .mul(tranche1Price);
+      .mul(tokenPower)
+      .divToInt(tranche1Price)
+      .mul(tranche1Price)
+      .divToInt(tokenPower);
+    // smart contract tries to recover as much from the first tranche as possible
+    // const recoveredAmount = tranche1Amount.sub(tranche1QuantizedAmount);
     const tranche2QuantizedAmount = tranche2Amount
-      .div(tranche2Price)
-      .floor()
-      .mul(tranche2Price);
+      // .add(recoveredAmount)
+      .mul(tokenPower)
+      .divToInt(tranche2Price)
+      .mul(tranche2Price)
+      .divToInt(tokenPower);
     // still total amount was spent so effective price was higher for a tranche
+    // return non-integer value for precise calculations
     return totalAmount
       .mul(tranche1Price)
       .mul(tranche2Price)
       .div(
         tranche1Price.mul(tranche2QuantizedAmount).add(tranche2Price.mul(tranche1QuantizedAmount)),
-      )
-      .floor();
+      );
+  }
+
+  function calculateMixedTranchePrice(totalAmount, tranche1Amount, tranche1Price, tranche2Price) {
+    // this reproduces how smart contract calculates tokens exactly
+    const tranche2Amount = totalAmount.sub(tranche1Amount);
+    const tokenPower = getTokenPower();
+    const tranche1Tokens = tranche1Amount.mul(tokenPower).divToInt(tranche1Price);
+    const tranche2Tokens = tranche2Amount.mul(tokenPower).divToInt(tranche2Price);
+
+    // console.log(tranche1Tokens.add(tranche2Tokens).toString("10"));
+    const effectivePrice = totalAmount.mul(tokenPower).div(tranche1Tokens.add(tranche2Tokens));
+    // compare to our old linear approx of the same thing
+    expect(
+      calculateMixedTranchePriceLinear(totalAmount, tranche1Amount, tranche1Price, tranche2Price)
+        .sub(effectivePrice)
+        .abs(),
+    ).to.be.bignumber.lt(tokenPower.mul(2));
+    // note that it returns precision 20 decimal, not integer!
+    return effectivePrice;
   }
 
   function getMaxAvailableTokens(maxNumberOfTokens) {
     return maxNumberOfTokens.div(inverseTokenFeeDec).round(0, 4);
+    // return divRound(maxNumberOfTokens.mul("50"), new web3.BigNumber("51"));
   }
 
   async function expectExactlyMaxCap(maxNumberOfTokens) {

--- a/test/ETO/ETOTerms.js
+++ b/test/ETO/ETOTerms.js
@@ -231,10 +231,10 @@ contract("ETOTerms", ([, admin, investorDiscount, investorNoDiscount, ...investo
     it("rejects on tokens per share not in whole tokens", async () => {
       // tokens per share must be in whole tokens, so set tokens per share 1/10 of the whole tokens
       // so other "whole tokens" checks work but this particular don't
-      const precision = new web3.BigNumber("1");
+      const decimals = new web3.BigNumber("1");
       await expect(
         deployTokenTerms(ETOTokenTerms, {
-          EQUITY_TOKENS_PRECISION: precision, // one decimal place
+          EQUITY_TOKEN_DECIMALS: decimals, // one decimal place
           EQUITY_TOKENS_PER_SHARE: decimalBase.div(10), // scale is ten but set scale / 10
         }),
       ).to.be.rejectedWith("NF_SHARES_NOT_WHOLE_TOKENS");
@@ -361,13 +361,13 @@ contract("ETOTerms", ([, admin, investorDiscount, investorNoDiscount, ...investo
     });
 
     it("rejects if max tokens not fit in 2**128", async () => {
-      // force token precision of 0 (indivisible), to operate on 32bytes word range
+      // force token decimals of 0 (indivisible), to operate on 32bytes word range
       const b2 = new web3.BigNumber("2");
       const b1 = new web3.BigNumber("1");
       // should pass - just one share below 2**256
       await expect(
         deployTokenTerms(ETOTokenTerms, {
-          EQUITY_TOKENS_PRECISION: new web3.BigNumber("0"),
+          EQUITY_TOKEN_DECIMALS: new web3.BigNumber("0"),
           EQUITY_TOKENS_PER_SHARE: b1,
           MAX_NUMBER_OF_TOKENS: b2.pow(128).sub(b1),
           TOKEN_PRICE_EUR_ULPS: b1,
@@ -1181,7 +1181,7 @@ contract("ETOTerms", ([, admin, investorDiscount, investorNoDiscount, ...investo
   }
 
   function getTokenPower(t) {
-    return decimalBase.pow(t.EQUITY_TOKENS_PRECISION);
+    return decimalBase.pow(t.EQUITY_TOKEN_DECIMALS);
   }
 
   function expectLogInvestorWhitelisted(event, investor, discountAmount, priceFracFrac) {

--- a/test/ETO/ETOTerms.js
+++ b/test/ETO/ETOTerms.js
@@ -14,6 +14,7 @@ import {
   deployETOTermsConstraints,
   deployETOTerms,
   defTokenTerms,
+  verifyTerms,
 } from "../helpers/deployTerms";
 import { Q18, contractId, web3, defEquityTokenPower, decimalBase } from "../helpers/constants";
 import roles from "../helpers/roles";
@@ -86,17 +87,6 @@ contract("ETOTerms", ([, admin, investorDiscount, investorNoDiscount, ...investo
       { role: roles.whitelistAdmin, object: _etoTerms.address, subject: admin },
     ]);
     return [deployedTerms, _etoTerms, _termsKeys, termsValues];
-  }
-
-  async function verifyTerms(c, keys, dict) {
-    for (const f of keys) {
-      const rv = await c[f]();
-      if (rv instanceof Object) {
-        expect(rv, f).to.be.bignumber.eq(dict[f]);
-      } else {
-        expect(rv, f).to.eq(dict[f]);
-      }
-    }
   }
 
   it("should reject constraints not in universe", async () => {
@@ -390,7 +380,7 @@ contract("ETOTerms", ([, admin, investorDiscount, investorNoDiscount, ...investo
         .div(tokenTerms.MAX_NUMBER_OF_TOKENS)
         .mul(getTokenPower(tokenTerms))
         .floor();
-      // should
+      // should pass
       await deployTokenTerms(ETOTokenTerms, {
         TOKEN_PRICE_EUR_ULPS: maxTokenPrice,
       });

--- a/test/ETO/EquityToken.js
+++ b/test/ETO/EquityToken.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { prettyPrintGasCost } from "../helpers/gasUtils";
 import { deployUniverse, deployPlatformTerms } from "../helpers/deployContracts";
-import { deployTokenTerms, constTokenTerms, defTokenTerms } from "../helpers/deployTerms";
+import { deployTokenTerms, defTokenTerms } from "../helpers/deployTerms";
 import {
   basicTokenTests,
   standardTokenTests,
@@ -22,7 +22,7 @@ import createAccessPolicy from "../helpers/createAccessPolicy";
 import { snapshotTokenTests } from "../helpers/snapshotTokenTestCases";
 import { mineBlock } from "../helpers/evmCommands";
 import increaseTime from "../helpers/increaseTime";
-import { contractId, ZERO_ADDRESS } from "../helpers/constants";
+import { contractId, ZERO_ADDRESS, defEquityTokenPrecision } from "../helpers/constants";
 import EvmError from "../helpers/EVMThrow";
 
 const EquityToken = artifacts.require("EquityToken");
@@ -65,9 +65,7 @@ contract("EquityToken", ([admin, nominee, company, broker, ...holders]) => {
       expect(await equityToken.shareNominalValueUlps()).to.be.bignumber.eq(
         tokenTermsDict.SHARE_NOMINAL_VALUE_ULPS,
       );
-      expect(await equityToken.decimals()).to.be.bignumber.eq(
-        constTokenTerms.EQUITY_TOKENS_PRECISION,
-      );
+      expect(await equityToken.decimals()).to.be.bignumber.eq(defEquityTokenPrecision);
       expect(await equityToken.tokenController()).to.be.bignumber.eq(equityTokenController.address);
       expect(await equityToken.nominee()).to.be.bignumber.eq(nominee);
       expect(await equityToken.companyLegalRepresentative()).to.be.bignumber.eq(company);

--- a/test/ETO/EquityToken.js
+++ b/test/ETO/EquityToken.js
@@ -22,7 +22,7 @@ import createAccessPolicy from "../helpers/createAccessPolicy";
 import { snapshotTokenTests } from "../helpers/snapshotTokenTestCases";
 import { mineBlock } from "../helpers/evmCommands";
 import increaseTime from "../helpers/increaseTime";
-import { contractId, ZERO_ADDRESS, defEquityTokenPrecision } from "../helpers/constants";
+import { contractId, ZERO_ADDRESS, defEquityTokenDecimals } from "../helpers/constants";
 import EvmError from "../helpers/EVMThrow";
 
 const EquityToken = artifacts.require("EquityToken");
@@ -65,12 +65,15 @@ contract("EquityToken", ([admin, nominee, company, broker, ...holders]) => {
       expect(await equityToken.shareNominalValueUlps()).to.be.bignumber.eq(
         tokenTermsDict.SHARE_NOMINAL_VALUE_ULPS,
       );
-      expect(await equityToken.decimals()).to.be.bignumber.eq(defEquityTokenPrecision);
+      expect(await equityToken.decimals()).to.be.bignumber.eq(defEquityTokenDecimals);
       expect(await equityToken.tokenController()).to.be.bignumber.eq(equityTokenController.address);
       expect(await equityToken.nominee()).to.be.bignumber.eq(nominee);
       expect(await equityToken.companyLegalRepresentative()).to.be.bignumber.eq(company);
 
       expect((await equityToken.contractId())[0]).to.eq(contractId("EquityToken"));
+
+      // eslint-disable-next-line no-console
+      console.log(`Default Equity Token decimals: ${defEquityTokenDecimals}`);
     });
 
     it("should deposit", async () => {
@@ -129,12 +132,12 @@ contract("EquityToken", ([admin, nominee, company, broker, ...holders]) => {
       const equityTokenSymbol = await tokenTerms.EQUITY_TOKEN_SYMBOL();
       const equityTokenShareNominalValue = await tokenTerms.SHARE_NOMINAL_VALUE_ULPS();
       const equityTokenShareNominalEurValue = await tokenTerms.SHARE_NOMINAL_VALUE_EUR_ULPS();
-      const equityTokenPrecision = await tokenTerms.EQUITY_TOKENS_PRECISION();
+      const equityTokenDecimals = await tokenTerms.EQUITY_TOKEN_DECIMALS();
       const equityTokensPerShare = await tokenTerms.EQUITY_TOKENS_PER_SHARE();
 
       expect(await equityToken.name()).to.have.string(equityTokenName);
       expect(await equityToken.symbol()).to.have.string(equityTokenSymbol);
-      expect(await equityToken.decimals()).to.be.bignumber.eq(equityTokenPrecision);
+      expect(await equityToken.decimals()).to.be.bignumber.eq(equityTokenDecimals);
       expect(await equityToken.tokensPerShare()).to.be.bignumber.eq(equityTokensPerShare);
       expect(await equityToken.shareNominalValueUlps()).to.be.bignumber.eq(
         equityTokenShareNominalValue,

--- a/test/ETO/PlaceholderEquityTokenController.js
+++ b/test/ETO/PlaceholderEquityTokenController.js
@@ -966,7 +966,7 @@ contract("PlaceholderEquityTokenController", ([_, admin, company, nominee, ...in
   }
 
   function getTokenPower(terms) {
-    return decimalBase.pow((terms || tokenTermsDict).EQUITY_TOKENS_PRECISION);
+    return decimalBase.pow((terms || tokenTermsDict).EQUITY_TOKEN_DECIMALS);
   }
 
   function expectLogResolutionExecuted(tx, logIdx, resolutionId, actionType) {

--- a/test/ETO/PlaceholderEquityTokenController.js
+++ b/test/ETO/PlaceholderEquityTokenController.js
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { deployPlatformTerms, deployUniverse } from "../helpers/deployContracts";
-import { contractId, ZERO_ADDRESS, toBytes32, Q18 } from "../helpers/constants";
+import { contractId, ZERO_ADDRESS, toBytes32, Q18, decimalBase } from "../helpers/constants";
 import { prettyPrintGasCost } from "../helpers/gasUtils";
 import { GovState, GovAction } from "../helpers/govState";
 import { CommitmentState } from "../helpers/commitmentState";
@@ -227,7 +227,8 @@ contract("PlaceholderEquityTokenController", ([_, admin, company, nominee, ...in
       const expectedValuation = divRound(
         increasedShareCapitalUlps
           .mul(tokenTermsDict.EQUITY_TOKENS_PER_SHARE)
-          .mul(tokenTermsDict.TOKEN_PRICE_EUR_ULPS),
+          .mul(tokenTermsDict.TOKEN_PRICE_EUR_ULPS)
+          .divToInt(getTokenPower()),
         tokenTermsDict.SHARE_NOMINAL_VALUE_ULPS,
       );
       expectLogISHAAmended(
@@ -962,6 +963,10 @@ contract("PlaceholderEquityTokenController", ([_, admin, company, nominee, ...in
       { from: admin },
     );
     await testCommitment.amendAgreement("AGREEMENT#HASH", { from: nominee });
+  }
+
+  function getTokenPower(terms) {
+    return decimalBase.pow((terms || tokenTermsDict).EQUITY_TOKENS_PRECISION);
   }
 
   function expectLogResolutionExecuted(tx, logIdx, resolutionId, actionType) {

--- a/test/Math.js
+++ b/test/Math.js
@@ -60,7 +60,7 @@ contract("Math", () => {
   });
 
   it("should compute fractions", async () => {
-    // fractions are computed on 18 decimal places precision
+    // fractions are computed on 18 decimal places scale
     const amount = Q18.mul(100);
     const full = Q18; // 100%
     expect(await math._decimalFraction(amount, full)).to.be.bignumber.eq(amount);

--- a/test/PlatformTerms.js
+++ b/test/PlatformTerms.js
@@ -3,6 +3,7 @@ import { prettyPrintGasCost } from "./helpers/gasUtils";
 import { divRound, etherToWei } from "./helpers/unitConverter";
 import { deployUniverse, deployPlatformTerms } from "./helpers/deployContracts";
 import { contractId, Q18 } from "./helpers/constants";
+import { verifyTerms } from "./helpers/deployTerms";
 
 contract("PlatformTerms", ([_, admin]) => {
   let platformTerms;
@@ -17,17 +18,6 @@ contract("PlatformTerms", ([_, admin]) => {
   it("should deploy", async () => {
     await prettyPrintGasCost("PlatformTerms deploy", platformTerms);
   });
-
-  async function verifyTerms(c, keys, dict) {
-    for (const f of keys) {
-      const rv = await c[f]();
-      if (rv instanceof Object) {
-        expect(rv, f).to.be.bignumber.eq(dict[f]);
-      } else {
-        expect(rv, f).to.eq(dict[f]);
-      }
-    }
-  }
 
   it("should have all the constants", async () => {
     await verifyTerms(platformTerms, termsKeys, defaultTerms);

--- a/test/PlatformTerms.js
+++ b/test/PlatformTerms.js
@@ -42,11 +42,10 @@ contract("PlatformTerms", ([_, admin]) => {
   });
 
   it("should calculate platform token fee correctly", async () => {
-    // tokens have 0 precision
-    const amountInt = new web3.BigNumber("7128918927");
-    const feeAmount = await platformTerms.calculatePlatformTokenFee(amountInt);
+    const amount = new web3.BigNumber("7128918927");
+    const feeAmount = await platformTerms.calculatePlatformTokenFee(amount);
     const fee = defaultTerms.TOKEN_PARTICIPATION_FEE_FRACTION;
-    expect(feeAmount).to.be.bignumber.eq(amountInt.mul(fee.div(Q18)).round(0, 4));
+    expect(feeAmount).to.be.bignumber.eq(amount.mul(fee.div(Q18)).round(0, 4));
   });
 
   it("should calculate neumark share when reward is 0 wei", async () => {

--- a/test/helpers/constants.js
+++ b/test/helpers/constants.js
@@ -9,12 +9,10 @@ export const dayInSeconds = 24 * hourInSeconds;
 export const monthInSeconds = 30 * dayInSeconds;
 export const daysToSeconds = sec => sec * dayInSeconds;
 export const hoursToSeconds = sec => sec * hourInSeconds;
-// default precision and power of equity token as used by fixtures and default test terms
-// allow to override from env variable to run ETO tests several precisions
-export const defEquityTokenPrecision = new web3.BigNumber(
-  process.env.EQUITY_TOKEN_PRECISION || "18",
-);
-export const defEquityTokenPower = decimalBase.pow(defEquityTokenPrecision);
+// default scale and power of equity token as used by fixtures and default test terms
+// allow to override from env variable to run ETO tests several scales
+export const defEquityTokenDecimals = new web3.BigNumber(process.env.EQUITY_TOKEN_DECIMALS || "18");
+export const defEquityTokenPower = decimalBase.pow(defEquityTokenDecimals);
 // default tokens per share used as above
 export const defaultTokensPerShare = defEquityTokenPower.mul(new web3.BigNumber("1000000"));
 

--- a/test/helpers/constants.js
+++ b/test/helpers/constants.js
@@ -2,12 +2,21 @@ const Web3 = require("web3");
 
 export const web3 = new Web3();
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-export const Q18 = web3.toBigNumber("10").pow(18);
+export const decimalBase = new web3.BigNumber("10");
+export const Q18 = decimalBase.pow(18);
 export const hourInSeconds = 60 * 60;
 export const dayInSeconds = 24 * hourInSeconds;
 export const monthInSeconds = 30 * dayInSeconds;
 export const daysToSeconds = sec => sec * dayInSeconds;
 export const hoursToSeconds = sec => sec * hourInSeconds;
+// default precision and power of equity token as used by fixtures and default test terms
+// allow to override from env variable to run ETO tests several precisions
+export const defEquityTokenPrecision = new web3.BigNumber(
+  process.env.EQUITY_TOKEN_PRECISION || "18",
+);
+export const defEquityTokenPower = decimalBase.pow(defEquityTokenPrecision);
+// default tokens per share used as above
+export const defaultTokensPerShare = defEquityTokenPower.mul(new web3.BigNumber("1000000"));
 
 export function toBytes32(hexOrNumber) {
   let strippedHex = "0";

--- a/test/helpers/dataset.js
+++ b/test/helpers/dataset.js
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 
 export function parseNmkDataset(fileName) {
-  // parses CSV file generated from Mathematica. All numbers have 36 digits precision to approximate 18 decimals precision of Neumark token
+  // parses CSV file generated from Mathematica. All numbers have 36 digits precision to approximate 18 decimals scale of Neumark token
   const lines = fs
     .readFileSync(fileName)
     .toString()

--- a/test/helpers/deployTerms.js
+++ b/test/helpers/deployTerms.js
@@ -5,7 +5,7 @@ import {
   findConstructor,
   camelCase,
   defaultTokensPerShare,
-  defEquityTokenPrecision,
+  defEquityTokenDecimals,
 } from "./constants";
 import { knownInterfaces } from "../helpers/knownInterfaces";
 
@@ -39,7 +39,7 @@ export const defTokenTerms = {
   SHARE_NOMINAL_VALUE_EUR_ULPS: Q18,
   SHARE_NOMINAL_VALUE_ULPS: Q18.mul("4.24566"),
   EQUITY_TOKENS_PER_SHARE: defaultTokensPerShare,
-  EQUITY_TOKENS_PRECISION: defEquityTokenPrecision,
+  EQUITY_TOKEN_DECIMALS: defEquityTokenDecimals,
 };
 
 export const defEtoTerms = {

--- a/test/helpers/deployTerms.js
+++ b/test/helpers/deployTerms.js
@@ -1,4 +1,12 @@
-import { daysToSeconds, Q18, web3, findConstructor, camelCase } from "./constants";
+import {
+  daysToSeconds,
+  Q18,
+  web3,
+  findConstructor,
+  camelCase,
+  defaultTokensPerShare,
+  defEquityTokenPrecision,
+} from "./constants";
 import { knownInterfaces } from "../helpers/knownInterfaces";
 
 export const defaultShareholderTerms = {
@@ -21,12 +29,6 @@ export const defDurTerms = {
   CLAIM_DURATION: new web3.BigNumber(daysToSeconds(10)),
 };
 
-export const constTokenTerms = {
-  EQUITY_TOKENS_PRECISION: new web3.BigNumber(0),
-};
-
-const defaultTokensPerShare = new web3.BigNumber("1000000");
-
 export const defTokenTerms = {
   EQUITY_TOKEN_NAME: "Quintessence",
   EQUITY_TOKEN_SYMBOL: "FFT",
@@ -37,6 +39,7 @@ export const defTokenTerms = {
   SHARE_NOMINAL_VALUE_EUR_ULPS: Q18,
   SHARE_NOMINAL_VALUE_ULPS: Q18.mul("4.24566"),
   EQUITY_TOKENS_PER_SHARE: defaultTokensPerShare,
+  EQUITY_TOKENS_PRECISION: defEquityTokenPrecision,
 };
 
 export const defEtoTerms = {
@@ -49,7 +52,7 @@ export const defEtoTerms = {
   ENABLE_TRANSFERS_ON_SUCCESS: false,
   INVESTOR_OFFERING_DOCUMENT_URL: "893289290300923809jdkljoi3",
   SHAREHOLDER_RIGHTS: null,
-  WHITELIST_DISCOUNT_FRAC: Q18.mul(0.3),
+  WHITELIST_DISCOUNT_FRAC: Q18.mul("0.3"),
   PUBLIC_DISCOUNT_FRAC: Q18.mul(0),
 };
 

--- a/test/helpers/deployTerms.js
+++ b/test/helpers/deployTerms.js
@@ -1,3 +1,4 @@
+import { expect } from "chai";
 import {
   daysToSeconds,
   Q18,
@@ -128,6 +129,17 @@ export function validateTerms(artifact, terms) {
     idx += 1;
   }
   return [Object.keys(terms), termsValues];
+}
+
+export async function verifyTerms(c, keys, dict) {
+  for (const f of keys) {
+    const rv = await c[f]();
+    if (rv instanceof Object) {
+      expect(rv, f).to.be.bignumber.eq(dict[f]);
+    } else {
+      expect(rv, f).to.eq(dict[f]);
+    }
+  }
 }
 
 export async function deployShareholderRights(artifact, terms, fullTerms) {


### PR DESCRIPTION
This PR adds ability to send decimals for equity tokens. Currently we assumed that all equity tokens are indivisible (0 decimals), however DeFi applications and other dapps often assume 18 decimals to be a standard.
On top of that we solve a few rounding issues where for given amount of EUR non exact number of tokens could be purchased - and we were rounding down.

Contracts and tests are updated to allow any number of decimals. Several additional rounding issues were found and fixed in tests.

See `ETOTerms::calculateTokenAmount` and `ETOTerms::calculateEurUlpsAmount` for new formulas to calculate token amount and the reverse. `EQUITY_TOKEN_POWER` is `10**decimals` which was `1` for indivisible tokens, giving the old formula. All tests were updated accordingly.

See commit lists for the exact scope