### PR TITLE
emits start date event on time travel

### DIFF
--- a/contracts/test/ETO/MockETOCommitment.sol
+++ b/contracts/test/ETO/MockETOCommitment.sol
@@ -48,9 +48,14 @@ contract MockETOCommitment is
     // @dev maximum to be shifted is to three days before state transition
     function _shiftToBeforeNextState(uint32 delta) public {
         require(delta < 86400, "NF_MOCK_INVALID_DELTA");
-        uint256 nextTransition = startOfInternal(ETOState(uint(state()) + 1));
+        ETOState s = state();
+        uint256 nextTransition = startOfInternal(ETOState(uint(s) + 1));
         require(nextTransition != 0 && nextTransition > now + delta, "NF_MOCK_INVALID_TRANSITION_TIME");
         _mockShiftBackTime(nextTransition - now - delta);
+        // generate set start date if still in setup
+        if (s == ETOState.Setup) {
+            emit LogETOStartDateSet(msg.sender, nextTransition, nextTransition - delta);
+        }
     }
 
     function _mockPastTime(uint256 idx, uint256 timestamp) public {

--- a/test/ETO/ETOCommitment.js
+++ b/test/ETO/ETOCommitment.js
@@ -388,25 +388,27 @@ contract("ETOCommitment", ([, admin, company, nominee, ...investors]) => {
       const timestamp = await latestTimestamp();
       durTable = defaultDurationTable();
       startDate = new web3.BigNumber(timestamp + 2 * dayInSeconds);
-      const whitelistD = durTable[CommitmentState.Whitelist].add(1);
       // set start data to 2 days from now via mocker
-      const startTx = await etoCommitment._mockStartDate(
+      let startTx = await etoCommitment._mockStartDate(
         etoTerms.address,
         equityToken.address,
         startDate,
-        startDate.add(whitelistD),
+        startDate,
         { from: company },
       );
-      expectLogETOStartDateSet(startTx, company, 0, startDate.add(whitelistD));
+      expectLogETOStartDateSet(startTx, company, 0, startDate);
 
       // move to right before startDate via mocker
-      await etoCommitment._shiftToBeforeNextState(10);
+      startTx = await etoCommitment._shiftToBeforeNextState(10, { from: company });
+      expectLogETOStartDateSet(startTx, company, startDate, startDate.sub(10));
+
       await increaseTime(15);
       const tx = await etoCommitment.handleStateTransitions();
       expectLogStateTransition(tx, CommitmentState.Setup, CommitmentState.Whitelist, "ignore");
 
       // do so again for whitelist->public transition
-      await etoCommitment._shiftToBeforeNextState(10);
+      const nextTx = await etoCommitment._shiftToBeforeNextState(10);
+      expect(hasEvent(nextTx, "LogETOStartDateSet")).to.be.false;
       await increaseTime(15);
       const tx2 = await etoCommitment.handleStateTransitions();
       expectLogStateTransition(tx2, CommitmentState.Whitelist, CommitmentState.Public, "ignore");


### PR DESCRIPTION
this emits LogSetStartDate event when we do time travel in `Setup` state to let backend update start date to the right time

That will fix problems with frontend e2e tests